### PR TITLE
Release tooling: signed release + bump-version (bump to 1.0.6)

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,56 @@
+# Manual version bump: pick a bump type, the new version is computed from the current one
+# (always valid semver, strictly greater, can't jump). Sets the version in every place it
+# lives and opens a PR - main is protected, so no direct pushes. Merge the PR, then run
+# Release (model A: release.yml tags whatever version is on main). The commit is authored
+# by whoever triggers the workflow.
+
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: "Version bump"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Bump and sync version
+        id: bump
+        run: |
+          ( cd src && npm version "${{ inputs.type }}" --no-git-tag-version >/dev/null )
+          NEW="$(jq -r .version src/package.json)"
+          echo "Bumped to $NEW"
+          sed -i -E "s/(public const string Version = \")[^\"]*(\";)/\1$NEW\2/" src/Runtime/PackageInfo.cs
+          sed -i -E "s/^(  bundleVersion: ).*/\1$NEW/" "Appegy.BinaryPrefs.Lab/ProjectSettings/ProjectSettings.asset"
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Open version-bump PR (authored by whoever ran this)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NEW="${{ steps.bump.outputs.version }}"
+          BRANCH="bump/v$NEW"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git commit -am "Bump version to $NEW"
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "Bump version to $NEW" \
+            --body "Sets the package version to \`$NEW\` in src/package.json, src/Runtime/PackageInfo.cs, and the dev project's bundleVersion. Merge, then run Release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+# Manual signed release: packs src/ into a .tgz, signs it with the Unity UPM CLI, tags the
+# version, and publishes a GitHub Release with auto-generated notes.
+# Version comes from src/package.json (model A) - bump it first (bump-version.yml) to cut a new one.
+# Secrets required: UPM_SERVICE_ACCOUNT_KEY_ID / UPM_SERVICE_ACCOUNT_KEY_SECRET / UPM_ORG_ID.
+
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Pack, sign and release
+    runs-on: ubuntu-latest
+    env:
+      UPM_SERVICE_ACCOUNT_KEY_ID: ${{ secrets.UPM_SERVICE_ACCOUNT_KEY_ID }}
+      UPM_SERVICE_ACCOUNT_KEY_SECRET: ${{ secrets.UPM_SERVICE_ACCOUNT_KEY_SECRET }}
+      UPM_ORG_ID: ${{ secrets.UPM_ORG_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Read package version
+        id: pkg
+        run: |
+          VERSION="$(jq -r .version src/package.json)"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "No version found in src/package.json"; exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION"
+
+      - name: Ensure tag does not already exist
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.pkg.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.pkg.outputs.tag }} already exists - bump the version before releasing."
+            exit 1
+          fi
+
+      - name: Stage package contents
+        run: |
+          rm -rf pack out && mkdir -p pack out
+          cp -R src/. pack/
+          # README/LICENSE live at the repo root - fold them into the package.
+          for f in README.md LICENSE; do
+            [ -f "$f" ] && cp "$f" pack/
+          done
+
+      - name: Install Unity UPM CLI
+        run: |
+          curl -fsSL https://cdn.packages.unity.com/upm-cli/install.sh -o install.sh
+          bash install.sh
+          echo "$HOME/.upm/bin" >> "$GITHUB_PATH"
+
+      - name: Pack and sign
+        id: pack
+        run: |
+          upm pack ./pack --organization-id "$UPM_ORG_ID" --destination out
+          TGZ="$(ls out/*.tgz out/*.tar.gz 2>/dev/null | head -1)"
+          [ -n "$TGZ" ] || { echo "No archive produced by upm pack"; exit 1; }
+          tar -tzf "$TGZ" | grep -qx 'package/package.json'        || { echo "Malformed package"; exit 1; }
+          tar -tzf "$TGZ" | grep -qx 'package/.attestation.p7m'    || { echo "No .attestation.p7m - package is NOT signed"; exit 1; }
+          echo "tgz=$TGZ" >> "$GITHUB_OUTPUT"
+          echo "Signed $TGZ - contents:"; tar -tzf "$TGZ"
+
+      - name: Create and push tag
+        run: |
+          git tag "${{ steps.pkg.outputs.tag }}"
+          git push origin "${{ steps.pkg.outputs.tag }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.pkg.outputs.tag }}" "${{ steps.pack.outputs.tgz }}" \
+            --title "${{ steps.pkg.outputs.tag }}" \
+            --generate-notes

--- a/Appegy.BinaryPrefs.Lab/ProjectSettings/ProjectSettings.asset
+++ b/Appegy.BinaryPrefs.Lab/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.0.5
+  bundleVersion: 1.0.6
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/src/Runtime/PackageInfo.cs
+++ b/src/Runtime/PackageInfo.cs
@@ -9,7 +9,7 @@ namespace Appegy.Storage
     public static class PackageInfo
     {
         public const string Name = "com.appegy.binary-prefs";
-        public const string Version = "1.0.5";
+        public const string Version = "1.0.6";
         public static string PersistentFolder => Path.Combine(Application.persistentDataPath, Name);
     }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "com.appegy.binary-prefs",
   "displayName": "Appegy: Binary Prefs",
   "description": "Fast persistant thread-safe binary storage for Unity.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "unity": "6000.0",
   "documentationUrl": "https://github.com/Appegy/BinaryPrefs",
   "changelogUrl": "https://github.com/Appegy/BinaryPrefs/releases",


### PR DESCRIPTION
Adds the signed release pipeline, matching Tessera:
- `release.yml`: pack `src/` + sign via Unity UPM CLI, tag, GitHub Release with auto-notes.
- `bump-version.yml`: choose patch/minor/major, opens a bump PR (version synced across package.json, PackageInfo.cs, bundleVersion).
- Bump 1.0.6 (the previous version is already tagged), so the first signed release can be cut after merge.

Secrets UPM_* are set on this repo. After merge: run Release, then submit the OpenUPM trackingMode: githubRelease config.