### PR TITLE
fix: correct IsCollection so the collection guard works

### DIFF
--- a/src/Runtime/Utilities/CollectionExtensions.cs
+++ b/src/Runtime/Utilities/CollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Appegy.Storage
 {
@@ -64,12 +65,7 @@ namespace Appegy.Storage
 
         public static bool IsCollection(this Type type)
         {
-            if (!type.IsGenericType)
-            {
-                return false;
-            }
-            var genericTypeDefinition = type.GetGenericTypeDefinition();
-            return typeof(ICollection<>).IsAssignableFrom(genericTypeDefinition);
+            return type.GetInterfaces().Append(type).Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICollection<>));
         }
 
         public static void ForEach<T>(this Span<T> source, Action<T> predicate)

--- a/src/Tests/CollectionGuardTests.cs
+++ b/src/Tests/CollectionGuardTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class CollectionGuardTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenSetCalledWithCollectionType_ThenThrows()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            storage.Invoking(s => s.Set("key", new List<int> { 1, 2, 3 }))
+                .Should().Throw<IncorrectUsageOfCollectionException>();
+        }
+
+        [Test]
+        public void WhenGetCalledWithCollectionType_ThenThrows()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            storage.Invoking(s => s.Get<List<int>>("key"))
+                .Should().Throw<IncorrectUsageOfCollectionException>();
+        }
+
+        [Test]
+        public void WhenSetRawCalledWithCollectionInstance_ThenThrows()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            storage.Invoking(s => s.SetRaw("key", new List<int> { 1 }))
+                .Should().Throw<IncorrectUsageOfCollectionException>();
+        }
+
+        [Test]
+        public void WhenSupportsCalledWithCollectionType_ThenThrows()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            storage.Invoking(s => s.Supports<List<int>>())
+                .Should().Throw<IncorrectUsageOfCollectionException>();
+        }
+
+        [Test]
+        public void WhenStringValueUsed_ThenNotTreatedAsCollection()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            storage.Set("name", "John");
+
+            storage.Get("name", string.Empty).Should().Be("John");
+        }
+
+        [Test]
+        public void WhenCollectionApiUsed_ThenWorksWithoutThrowing()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SupportListsOf<int>()
+                .Build();
+
+            var list = storage.GetListOf<int>("nums");
+            list.Add(1);
+            list.Add(2);
+
+            storage.GetListOf<int>("nums").Should().BeEquivalentTo(new[] { 1, 2 });
+        }
+    }
+}

--- a/src/Tests/CollectionGuardTests.cs.meta
+++ b/src/Tests/CollectionGuardTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3432862abcd0463da9649d072faea616
+timeCreated: 1718628962


### PR DESCRIPTION
IsCollection used IsAssignableFrom on an open generic, which is always false, so the guard never fired. Fixed via interface scan. Adds CollectionGuardTests.