### PR TITLE
fix: harden load against per-key and structural file corruption

### DIFF
--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -142,6 +142,11 @@ namespace Appegy.Storage
                 var position = stream.Position;
 
                 // #09 <---> Read value from stream
+                if (typeIndex < 0 || typeIndex >= orderedSectionsFromFile.Length)
+                {
+                    failedToLoadKey($"Type index {typeIndex} is out of range");
+                    continue;
+                }
                 var section = orderedSectionsFromFile[typeIndex];
                 var index = sections.FindIndex(c => c == section);
                 if (section == null || index == -1)
@@ -149,37 +154,41 @@ namespace Appegy.Storage
                     failedToLoadKey("Unregistered type serializer");
                     continue;
                 }
+
+                Record value;
                 try
                 {
-                    var value = section.ReadFrom(reader, index);
-                    if (stream.Position != position + entrySize)
-                    {
-                        failedToLoadKey($"Read more than expected ({stream.Position - position}b)");
-                    }
-                    else
-                    {
-                        section.Count++;
-                        data.Add(key, value);
-                    }
+                    value = section.ReadFrom(reader, index);
                 }
-                catch (EndOfStreamException e)
+                catch (Exception e)
                 {
-                    failedToLoadKey("End of file stream", e);
+                    failedToLoadKey("Failed to deserialize value", e);
+                    continue;
                 }
+
+                if (stream.Position != position + entrySize)
+                {
+                    failedToLoadKey($"Read more than expected ({stream.Position - position}b)");
+                    continue;
+                }
+
+                section.Count++;
+                data.Add(key, value);
 
                 void failedToLoadKey(string reason, Exception exception = null)
                 {
                     // move stream position to the next record
                     stream.Position = Math.Min(position + entrySize, stream.Length);
 
+                    var typeName = typeIndex >= 0 && typeIndex < sectionsNames.Length ? sectionsNames[typeIndex] : "<unknown>";
                     switch (keyLoadFailedBehaviour)
                     {
                         case KeyLoadFailedBehaviour.ThrowException:
-                            throw exception ?? new KeyLoadFailedException(key, sectionsNames[typeIndex], entrySize, reason);
+                            throw exception ?? new KeyLoadFailedException(key, typeName, entrySize, reason);
                         case KeyLoadFailedBehaviour.Ignore:
                             break;
                         case KeyLoadFailedBehaviour.IgnoreWithWarning:
-                            Debug.LogWarning($"Failed to load key {key} of type {sectionsNames[typeIndex]} with size {entrySize}b. Reason: {reason}");
+                            Debug.LogWarning($"Failed to load key {key} of type {typeName} with size {entrySize}b. Reason: {reason}");
                             break;
                         default:
                             throw new UnexpectedEnumException(typeof(KeyLoadFailedBehaviour), keyLoadFailedBehaviour);

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -106,39 +106,67 @@ namespace Appegy.Storage
             using var stream = new FileStream(storageFilePath, FileMode.Open);
             using var reader = new BinaryReader(stream, Encoding.UTF8);
 
-            // #01 <---> Read package version from the start of the file
-            reader.ReadString();
-
-            // #02 <---> Read and skip reserved 8 bytes
-            reader.ReadInt64();
-
-            // #03 <---> Read used serializers amount
-            var serializersCount = reader.ReadInt32();
-            var orderedSectionsFromFile = new BinarySection[serializersCount];
-            var sectionsNames = new string[serializersCount];
-
-            for (var i = 0; i < serializersCount; i++)
+            int serializersCount;
+            BinarySection[] orderedSectionsFromFile;
+            string[] sectionsNames;
+            int count;
+            try
             {
-                // #04 <---> Read name of type in serializer
-                var serializerName = reader.ReadString();
-                sectionsNames[i] = serializerName;
-                var serializer = sections.FirstOrDefault(c => c.TypeName == serializerName);
-                // orderedSectionsFromFile[i] = serializer ?? throw new UnregisteredTypeException(serializerName);
-                orderedSectionsFromFile[i] = serializer;
+                // #01 <---> Read package version from the start of the file
+                reader.ReadString();
+
+                // #02 <---> Read and skip reserved 8 bytes
+                reader.ReadInt64();
+
+                // #03 <---> Read used serializers amount
+                serializersCount = reader.ReadInt32();
+                if (serializersCount < 0 || serializersCount > stream.Length - stream.Position)
+                {
+                    throw new StorageFileCorruptedException(storageFilePath, $"Invalid serializer count {serializersCount}");
+                }
+                orderedSectionsFromFile = new BinarySection[serializersCount];
+                sectionsNames = new string[serializersCount];
+
+                for (var i = 0; i < serializersCount; i++)
+                {
+                    // #04 <---> Read name of type in serializer
+                    var serializerName = reader.ReadString();
+                    sectionsNames[i] = serializerName;
+                    orderedSectionsFromFile[i] = sections.FirstOrDefault(c => c.TypeName == serializerName);
+                }
+
+                // #05 <---> Read amount of records in storage
+                count = reader.ReadInt32();
+                if (count < 0)
+                {
+                    throw new StorageFileCorruptedException(storageFilePath, $"Invalid record count {count}");
+                }
+            }
+            catch (EndOfStreamException e)
+            {
+                throw new StorageFileCorruptedException(storageFilePath, "Unexpected end of file while reading header", e);
             }
 
-            // #05 <---> Read amount of records in storage
-            var count = reader.ReadInt32();
             for (var i = 0; i < count; i++)
             {
-                // #06 <---> Read key
-                var key = reader.ReadString();
+                string key;
+                int typeIndex;
+                long entrySize;
+                try
+                {
+                    // #06 <---> Read key
+                    key = reader.ReadString();
 
-                // #07 <---> Read type index
-                var typeIndex = reader.ReadInt32();
+                    // #07 <---> Read type index
+                    typeIndex = reader.ReadInt32();
 
-                // #08 <---> Read real size of entry
-                var entrySize = reader.ReadInt64();
+                    // #08 <---> Read real size of entry
+                    entrySize = reader.ReadInt64();
+                }
+                catch (EndOfStreamException e)
+                {
+                    throw new StorageFileCorruptedException(storageFilePath, "Unexpected end of file while reading record header", e);
+                }
                 var position = stream.Position;
 
                 // #09 <---> Read value from stream
@@ -172,6 +200,11 @@ namespace Appegy.Storage
                     continue;
                 }
 
+                if (data.ContainsKey(key))
+                {
+                    throw new StorageFileCorruptedException(storageFilePath, $"Duplicate key '{key}'");
+                }
+
                 section.Count++;
                 data.Add(key, value);
 
@@ -184,7 +217,7 @@ namespace Appegy.Storage
                     switch (keyLoadFailedBehaviour)
                     {
                         case KeyLoadFailedBehaviour.ThrowException:
-                            throw exception ?? new KeyLoadFailedException(key, typeName, entrySize, reason);
+                            throw new KeyLoadFailedException(key, typeName, entrySize, reason, exception);
                         case KeyLoadFailedBehaviour.Ignore:
                             break;
                         case KeyLoadFailedBehaviour.IgnoreWithWarning:

--- a/src/Runtime/Exceptions/KeyLoadFailedException.cs
+++ b/src/Runtime/Exceptions/KeyLoadFailedException.cs
@@ -8,5 +8,10 @@ namespace Appegy.Storage
             : base($"Failed to load key {key} of type {type} with size {size}b. Reason: {reason}")
         {
         }
+
+        public KeyLoadFailedException(string key, string type, long size, string reason, Exception innerException)
+            : base($"Failed to load key {key} of type {type} with size {size}b. Reason: {reason}", innerException)
+        {
+        }
     }
 }

--- a/src/Runtime/Exceptions/StorageFileCorruptedException.cs
+++ b/src/Runtime/Exceptions/StorageFileCorruptedException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Appegy.Storage
+{
+    public class StorageFileCorruptedException : Exception
+    {
+        public StorageFileCorruptedException(string filePath, string reason)
+            : base($"Storage file '{filePath}' is corrupted. Reason: {reason}")
+        {
+        }
+
+        public StorageFileCorruptedException(string filePath, string reason, Exception innerException)
+            : base($"Storage file '{filePath}' is corrupted. Reason: {reason}", innerException)
+        {
+        }
+    }
+}

--- a/src/Runtime/Exceptions/StorageFileCorruptedException.cs.meta
+++ b/src/Runtime/Exceptions/StorageFileCorruptedException.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 491cbf8896d0424eb67dbde565009ae8
+timeCreated: 1719231181

--- a/src/Tests/CorruptedLoadTests.cs
+++ b/src/Tests/CorruptedLoadTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class CorruptedLoadTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenTypeIndexOutOfRange_AndIgnore_ThenLoadDoesNotThrowAndKeySkipped()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("a", 1);
+                storage.Save();
+            }
+
+            CorruptFirstTypeIndex(StoragePath, 999);
+
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            reopened.Has("a").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenTypeIndexOutOfRange_AndThrow_ThenBuildThrows()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("a", 1);
+                storage.Save();
+            }
+
+            CorruptFirstTypeIndex(StoragePath, 999);
+
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException);
+
+            action.Should().Throw<KeyLoadFailedException>();
+        }
+
+        [Test]
+        public void WhenOneKeyCorrupted_AndIgnore_ThenOtherKeysStillLoad()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("a", 1);
+                storage.Set("b", 2);
+                storage.Save();
+            }
+
+            CorruptFirstTypeIndex(StoragePath, 999);
+
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            reopened.Keys.Count.Should().Be(1);
+        }
+
+        private static void CorruptFirstTypeIndex(string path, int badValue)
+        {
+            var offset = FindFirstTypeIndexOffset(path);
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8);
+            stream.Position = offset;
+            writer.Write(badValue);
+        }
+
+        private static long FindFirstTypeIndexOffset(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var reader = new BinaryReader(stream, Encoding.UTF8);
+            reader.ReadString();
+            reader.ReadInt64();
+            var serializersCount = reader.ReadInt32();
+            for (var i = 0; i < serializersCount; i++)
+            {
+                reader.ReadString();
+            }
+            reader.ReadInt32();
+            reader.ReadString();
+            return stream.Position;
+        }
+    }
+}

--- a/src/Tests/CorruptedLoadTests.cs
+++ b/src/Tests/CorruptedLoadTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Appegy.Storage
 {
@@ -41,7 +44,41 @@ namespace Appegy.Storage
         }
 
         [Test]
-        public void WhenOneKeyCorrupted_AndIgnore_ThenOtherKeysStillLoad()
+        public void WhenTypeIndexOutOfRange_AndIgnoreWithWarning_ThenWarningLoggedAndKeySkipped()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("a", 1);
+                storage.Save();
+            }
+
+            CorruptFirstTypeIndex(StoragePath, 999);
+
+            LogAssert.Expect(LogType.Warning, new Regex("Failed to load key a .*Type index 999 is out of range"));
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.IgnoreWithWarning);
+
+            reopened.Has("a").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenBuiltWithoutArgument_ThenDefaultsToIgnoreWithWarning()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("a", 1);
+                storage.Save();
+            }
+
+            CorruptFirstTypeIndex(StoragePath, 999);
+
+            LogAssert.Expect(LogType.Warning, new Regex("Failed to load key a .*Type index 999 is out of range"));
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            reopened.Has("a").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenOneKeyCorrupted_AndIgnore_ThenOtherKeyLoadsWithCorrectValue()
         {
             using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
             {
@@ -55,6 +92,92 @@ namespace Appegy.Storage
             using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
 
             reopened.Keys.Count.Should().Be(1);
+            if (reopened.Has("a"))
+            {
+                reopened.Get("a", 0).Should().Be(1);
+            }
+            else
+            {
+                reopened.Get("b", 0).Should().Be(2);
+            }
+        }
+
+        [Test]
+        public void WhenValueDeserializationFails_AndIgnore_ThenKeySkipped()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("k", "hello");
+                storage.Save();
+            }
+
+            CorruptFirstStringValueLength(StoragePath, -2);
+
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            reopened.Has("k").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenValueDeserializationFails_AndThrow_ThenThrowsKeyLoadFailedException()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("k", "hello");
+                storage.Save();
+            }
+
+            CorruptFirstStringValueLength(StoragePath, -2);
+
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException);
+
+            action.Should().Throw<KeyLoadFailedException>();
+        }
+
+        [Test]
+        public void WhenSerializerCountNegative_ThenThrowsCorruptedEvenInIgnore()
+        {
+            using (var stream = new FileStream(StoragePath, FileMode.Create, FileAccess.Write))
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+            {
+                writer.Write("1.0.0");
+                writer.Write(0L);
+                writer.Write(-1);
+            }
+
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            action.Should().Throw<StorageFileCorruptedException>();
+        }
+
+        [Test]
+        public void WhenHeaderTruncated_ThenThrowsCorruptedEvenInIgnore()
+        {
+            using (var stream = new FileStream(StoragePath, FileMode.Create, FileAccess.Write))
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+            {
+                writer.Write("1.0.0");
+            }
+
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            action.Should().Throw<StorageFileCorruptedException>();
+        }
+
+        [Test]
+        public void WhenDuplicateKey_ThenThrowsCorruptedEvenInIgnore()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build())
+            {
+                storage.Set("a", 1);
+                storage.Save();
+            }
+
+            DuplicateFirstRecord(StoragePath);
+
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            action.Should().Throw<StorageFileCorruptedException>();
         }
 
         private static void CorruptFirstTypeIndex(string path, int badValue)
@@ -64,6 +187,45 @@ namespace Appegy.Storage
             using var writer = new BinaryWriter(stream, Encoding.UTF8);
             stream.Position = offset;
             writer.Write(badValue);
+        }
+
+        private static void CorruptFirstStringValueLength(string path, int badLength)
+        {
+            var offset = FindFirstTypeIndexOffset(path) + sizeof(int) + sizeof(long);
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8);
+            stream.Position = offset;
+            writer.Write(badLength);
+        }
+
+        private static void DuplicateFirstRecord(string path)
+        {
+            var countOffset = FindRecordCountOffset(path);
+            var bytes = File.ReadAllBytes(path);
+            var recordsStart = (int)countOffset + sizeof(int);
+            var recordBlock = new byte[bytes.Length - recordsStart];
+            Array.Copy(bytes, recordsStart, recordBlock, 0, recordBlock.Length);
+
+            using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8);
+            writer.Write(bytes, 0, (int)countOffset);
+            writer.Write(2);
+            writer.Write(recordBlock);
+            writer.Write(recordBlock);
+        }
+
+        private static long FindRecordCountOffset(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var reader = new BinaryReader(stream, Encoding.UTF8);
+            reader.ReadString();
+            reader.ReadInt64();
+            var serializersCount = reader.ReadInt32();
+            for (var i = 0; i < serializersCount; i++)
+            {
+                reader.ReadString();
+            }
+            return stream.Position;
         }
 
         private static long FindFirstTypeIndexOffset(string path)

--- a/src/Tests/CorruptedLoadTests.cs.meta
+++ b/src/Tests/CorruptedLoadTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bed28f94f4b948b7a53d11bdbc21e708
+timeCreated: 1718628962


### PR DESCRIPTION
Per-key issues (bad typeIndex, deserialize fail, size mismatch) route through KeyLoadFailedBehaviour; ThrowException now always yields KeyLoadFailedException. Structural corruption (bad header counts, truncated header, duplicate keys) throws StorageFileCorruptedException regardless of mode. Adds CorruptedLoadTests covering all three modes incl. IgnoreWithWarning via LogAssert.