### PR TITLE
fix: disambiguate dictionary type names by namespace with legacy fallback

### DIFF
--- a/src/Runtime/BinarySection.cs
+++ b/src/Runtime/BinarySection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Appegy.Storage
@@ -17,6 +18,7 @@ namespace Appegy.Storage
         public abstract Type Type { get; }
 
         public abstract string TypeName { get; }
+        public abstract IReadOnlyList<string> FallbackNames { get; }
         public abstract Record ReadFrom(BinaryReader binaryReader, int typeIndex);
         public abstract void WriteTo(BinaryWriter binaryWriter, Record record);
 
@@ -40,6 +42,7 @@ namespace Appegy.Storage
         public new TypeSerializer<T> Serializer => _serializer;
         public override Type Type => typeof(T);
         public override string TypeName => Serializer.TypeName;
+        public override IReadOnlyList<string> FallbackNames => Serializer.FallbackNames;
 
         public TypedBinarySection(TypeSerializer<T> serializer)
             : base(serializer)

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -132,7 +132,8 @@ namespace Appegy.Storage
                     // #04 <---> Read name of type in serializer
                     var serializerName = reader.ReadString();
                     sectionsNames[i] = serializerName;
-                    orderedSectionsFromFile[i] = sections.FirstOrDefault(c => c.TypeName == serializerName);
+                    orderedSectionsFromFile[i] = sections.FirstOrDefault(c => c.TypeName == serializerName)
+                        ?? sections.FirstOrDefault(c => c.FallbackNames.Contains(serializerName));
                 }
 
                 // #05 <---> Read amount of records in storage

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -132,8 +132,7 @@ namespace Appegy.Storage
                     // #04 <---> Read name of type in serializer
                     var serializerName = reader.ReadString();
                     sectionsNames[i] = serializerName;
-                    orderedSectionsFromFile[i] = sections.FirstOrDefault(c => c.TypeName == serializerName)
-                        ?? sections.FirstOrDefault(c => c.FallbackNames.Contains(serializerName));
+                    orderedSectionsFromFile[i] = sections.FirstOrDefault(c => c.TypeName == serializerName) ?? sections.FirstOrDefault(c => c.FallbackNames.Contains(serializerName));
                 }
 
                 // #05 <---> Read amount of records in storage

--- a/src/Runtime/Serializers/CollectionTypeSerializer.cs
+++ b/src/Runtime/Serializers/CollectionTypeSerializer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Appegy.Storage.Serializers
 {
@@ -9,11 +10,15 @@ namespace Appegy.Storage.Serializers
         private readonly TypeSerializer<T> _typeSerializer;
 
         public override string TypeName { get; }
+        public override IReadOnlyList<string> FallbackNames { get; }
 
         public CollectionTypeSerializer(TypeSerializer<T> typeSerializer)
         {
             _typeSerializer = typeSerializer;
             TypeName = $"{typeof(TCollection).Name}<{typeSerializer.TypeName}>";
+            FallbackNames = typeSerializer.FallbackNames
+                .Select(fallback => $"{typeof(TCollection).Name}<{fallback}>")
+                .ToArray();
         }
 
         public override bool Equals(TCollection value1, TCollection value2)

--- a/src/Runtime/Serializers/KeyValueTypeSerializer.cs
+++ b/src/Runtime/Serializers/KeyValueTypeSerializer.cs
@@ -9,12 +9,14 @@ namespace Appegy.Storage.Serializers
         private readonly TypeSerializer<TValue> _valueSerializer;
 
         public override string TypeName { get; }
+        public override IReadOnlyList<string> FallbackNames { get; }
 
         public KeyValueTypeSerializer(TypeSerializer<TKey> keySerializer, TypeSerializer<TValue> valueSerializer)
         {
             _keySerializer = keySerializer;
             _valueSerializer = valueSerializer;
-            TypeName = $"{typeof(TKey).Name}:{typeof(TValue).Name}";
+            TypeName = $"{_keySerializer.TypeName}:{_valueSerializer.TypeName}";
+            FallbackNames = new[] { $"{typeof(TKey).Name}:{typeof(TValue).Name}" };
         }
 
         public override bool Equals(KeyValuePair<TKey, TValue> value1, KeyValuePair<TKey, TValue> value2)

--- a/src/Runtime/TypeSerializer.cs
+++ b/src/Runtime/TypeSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Appegy.Storage
@@ -6,6 +7,7 @@ namespace Appegy.Storage
     public abstract class TypeSerializer
     {
         public abstract string TypeName { get; }
+        public virtual IReadOnlyList<string> FallbackNames => Array.Empty<string>();
     }
 
     public abstract class TypeSerializer<T> : TypeSerializer

--- a/src/Tests/TypeNameCollisionTests.cs
+++ b/src/Tests/TypeNameCollisionTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage.CollisionA
+{
+    public struct Thing
+    {
+        public int Value;
+    }
+}
+
+namespace Appegy.Storage.CollisionB
+{
+    public struct Thing
+    {
+        public int Value;
+    }
+}
+
+namespace Appegy.Storage
+{
+    public class TypeNameCollisionTests : BaseStorageTests
+    {
+        private class ThingASerializer : TypeSerializer<CollisionA.Thing>
+        {
+            public override bool Equals(CollisionA.Thing a, CollisionA.Thing b) => a.Value == b.Value;
+            public override void WriteTo(BinaryWriter writer, CollisionA.Thing value) => writer.Write(value.Value);
+            public override CollisionA.Thing ReadFrom(BinaryReader reader) => new CollisionA.Thing { Value = reader.ReadInt32() };
+        }
+
+        private class ThingBSerializer : TypeSerializer<CollisionB.Thing>
+        {
+            public override bool Equals(CollisionB.Thing a, CollisionB.Thing b) => a.Value == b.Value;
+            public override void WriteTo(BinaryWriter writer, CollisionB.Thing value) => writer.Write(value.Value);
+            public override CollisionB.Thing ReadFrom(BinaryReader reader) => new CollisionB.Thing { Value = reader.ReadInt32() };
+        }
+
+        [Test]
+        public void WhenTwoDictionaryValueTypesShareShortName_ThenBothRegisterAndRoundTrip()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath)
+                       .AddPrimitiveTypes()
+                       .AddTypeSerializer(new ThingASerializer())
+                       .AddTypeSerializer(new ThingBSerializer())
+                       .SupportDictionariesOf<int, CollisionA.Thing>()
+                       .SupportDictionariesOf<int, CollisionB.Thing>()
+                       .Build())
+            {
+                storage.GetDictionaryOf<int, CollisionA.Thing>("a")[1] = new CollisionA.Thing { Value = 10 };
+                storage.GetDictionaryOf<int, CollisionB.Thing>("b")[1] = new CollisionB.Thing { Value = 20 };
+                storage.Save();
+            }
+
+            using var reopened = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .AddTypeSerializer(new ThingASerializer())
+                .AddTypeSerializer(new ThingBSerializer())
+                .SupportDictionariesOf<int, CollisionA.Thing>()
+                .SupportDictionariesOf<int, CollisionB.Thing>()
+                .Build();
+
+            reopened.GetReadOnlyDictionaryOf<int, CollisionA.Thing>("a")[1].Value.Should().Be(10);
+            reopened.GetReadOnlyDictionaryOf<int, CollisionB.Thing>("b")[1].Value.Should().Be(20);
+        }
+
+        [Test]
+        public void WhenDictionarySectionHasLegacyShortName_ThenLoadsViaFallback()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath)
+                       .AddPrimitiveTypes()
+                       .SupportDictionariesOf<string, int>()
+                       .Build())
+            {
+                storage.GetDictionaryOf<string, int>("d")["x"] = 5;
+                storage.Save();
+            }
+
+            RewriteSectionName(StoragePath, name => name.Contains("ReactiveDictionary"), "ReactiveDictionary`2<String:Int32>");
+
+            using var reopened = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SupportDictionariesOf<string, int>()
+                .Build();
+
+            reopened.GetReadOnlyDictionaryOf<string, int>("d")["x"].Should().Be(5);
+        }
+
+        private static void RewriteSectionName(string path, Func<string, bool> match, string replacement)
+        {
+            string version;
+            long reserved;
+            string[] names;
+            var records = new List<(string Key, int TypeIndex, byte[] Value)>();
+
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            using (var reader = new BinaryReader(stream, Encoding.UTF8))
+            {
+                version = reader.ReadString();
+                reserved = reader.ReadInt64();
+                var serializersCount = reader.ReadInt32();
+                names = new string[serializersCount];
+                for (var i = 0; i < serializersCount; i++)
+                {
+                    names[i] = reader.ReadString();
+                }
+                var count = reader.ReadInt32();
+                for (var i = 0; i < count; i++)
+                {
+                    var key = reader.ReadString();
+                    var typeIndex = reader.ReadInt32();
+                    var size = reader.ReadInt64();
+                    var value = reader.ReadBytes((int)size);
+                    records.Add((key, typeIndex, value));
+                }
+            }
+
+            for (var i = 0; i < names.Length; i++)
+            {
+                if (match(names[i]))
+                {
+                    names[i] = replacement;
+                }
+            }
+
+            using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+            {
+                writer.Write(version);
+                writer.Write(reserved);
+                writer.Write(names.Length);
+                foreach (var name in names)
+                {
+                    writer.Write(name);
+                }
+                writer.Write(records.Count);
+                foreach (var record in records)
+                {
+                    writer.Write(record.Key);
+                    writer.Write(record.TypeIndex);
+                    writer.Write((long)record.Value.Length);
+                    writer.Write(record.Value);
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/TypeNameCollisionTests.cs.meta
+++ b/src/Tests/TypeNameCollisionTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 524746e97d1c47db8c1cf65401eeb9a9
+timeCreated: 1718628962


### PR DESCRIPTION
KeyValueTypeSerializer named sections by short type names (typeof().Name), so two dict key/value types with the same short name in different namespaces collided. Now uses full names. Adds optional FallbackNames on serializers; loader matches TypeName then falls back to legacy short names, so old files still load. Tests cover the collision and the legacy-name fallback.