### PR TITLE
fix: flush unsaved changes on dispose when auto-save is enabled

### DIFF
--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -634,6 +634,11 @@ namespace Appegy.Storage
                 return;
             }
 
+            if (disposing && AutoSave && IsDirty)
+            {
+                SaveDataFromDisk();
+            }
+
             // Always dispose IReactiveCollection instances
             foreach (var rc in _data.Values.Select(c => c.Object).OfType<IReactiveCollection>())
             {

--- a/src/Tests/DisposeSaveTests.cs
+++ b/src/Tests/DisposeSaveTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class DisposeSaveTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenDisposedInsideOpenScope_AndAutoSave_ThenChangesPersisted()
+        {
+            var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().EnableAutoSaveOnChange().Build();
+            var scope = storage.MultipleChangeScope();
+            storage.Set("a", 42);
+            storage.Dispose();
+            scope.Dispose();
+
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().EnableAutoSaveOnChange().Build();
+
+            reopened.Get("a", 0).Should().Be(42);
+        }
+
+        [Test]
+        public void WhenDisposedWithoutAutoSave_ThenChangesNotPersisted()
+        {
+            var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Set("a", 42);
+            storage.Dispose();
+
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            reopened.Has("a").Should().BeFalse();
+        }
+    }
+}

--- a/src/Tests/DisposeSaveTests.cs.meta
+++ b/src/Tests/DisposeSaveTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5294ffa4122443ebbda3a77e491acb7e
+timeCreated: 1718628962


### PR DESCRIPTION
Disposing inside an open MultipleChangeScope dropped deferred changes (DecreaseCounter skips the save once IsDisposed). Dispose now flushes when AutoSave and IsDirty. Manual-save mode is unchanged.