### PR TITLE
fix: report actual collection type and caller in mismatch error

### DIFF
--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using UnityEngine.Pool;
 
@@ -397,14 +398,14 @@ namespace Appegy.Storage
         /// <returns>The collection associated with the key.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
-        private TCollection GetCollectionOf<T, TCollection>(string key)
+        private TCollection GetCollectionOf<T, TCollection>(string key, [CallerMemberName] string action = null)
             where TCollection : ICollection<T>, IReactiveCollection, new()
         {
             ThrowIfDisposed();
             var record = GetRecord(key) ?? AddRecord(key, new TCollection());
             if (record is not Record<TCollection> typedRecord)
             {
-                throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(IList<T>));
+                throw new UnexpectedTypeException(key, action, record.Type, typeof(TCollection));
             }
             return typedRecord.Value;
         }

--- a/src/Tests/CollectionKindMismatchTests.cs
+++ b/src/Tests/CollectionKindMismatchTests.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class CollectionKindMismatchTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenCollectionKindMismatched_ThenErrorMentionsActualCallAndType()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SupportListsOf<int>()
+                .SupportSetsOf<int>()
+                .Build();
+
+            storage.GetListOf<int>("k").Add(1);
+
+            Action action = () => storage.GetSetOf<int>("k");
+
+            action.Should().Throw<UnexpectedTypeException>()
+                .Where(e => e.Message.Contains("GetSetOf") && e.Message.Contains("ReactiveSet"));
+        }
+    }
+}

--- a/src/Tests/CollectionKindMismatchTests.cs.meta
+++ b/src/Tests/CollectionKindMismatchTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4d34f25abf634a64ab4163303f761438
+timeCreated: 1718628962


### PR DESCRIPTION
GetCollectionOf hardcoded the mismatch error to IList<T> and nameof(Get). Now uses the real TCollection type and [CallerMemberName] (GetListOf/GetSetOf/GetDictionaryOf), so the message reflects the actual call.