### PR TITLE
fix: throw on truncated string/char read and make ReactiveSet.Dispose idempotent

### DIFF
--- a/src/Runtime/Collections/ReactiveSet.cs
+++ b/src/Runtime/Collections/ReactiveSet.cs
@@ -30,7 +30,6 @@ namespace Appegy.Storage
 
         public void Dispose()
         {
-            ThrowIfDisposed();
             if (IsDisposed)
             {
                 return;

--- a/src/Runtime/Serializers/SystemTypesSerializers.cs
+++ b/src/Runtime/Serializers/SystemTypesSerializers.cs
@@ -35,7 +35,7 @@ namespace Appegy.Storage.Serializers
             if (read != size)
             {
                 ArrayPool<byte>.Shared.Return(buffer);
-                return default;
+                throw new EndOfStreamException($"Expected {size} bytes for char but read {read}.");
             }
             var value = BitConverter.ToChar(buffer);
             ArrayPool<byte>.Shared.Return(buffer);
@@ -175,7 +175,7 @@ namespace Appegy.Storage.Serializers
             if (read != size)
             {
                 ArrayPool<byte>.Shared.Return(buffer);
-                return string.Empty;
+                throw new EndOfStreamException($"Expected {size} bytes for string but read {read}.");
             }
             var value = Encoding.GetString(buffer, 0, size);
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/Tests/CollectionTests/ReactiveSetTests.cs
+++ b/src/Tests/CollectionTests/ReactiveSetTests.cs
@@ -21,6 +21,15 @@ namespace Appegy.Storage.CollectionTests
         }
 
         [Test]
+        public void WhenDisposedTwice_ThenSecondDisposeDoesNotThrow()
+        {
+            var set = new ReactiveSet<int>();
+            set.Dispose();
+
+            set.Invoking(s => s.Dispose()).Should().NotThrow();
+        }
+
+        [Test]
         public void WhenItemIsRemoved_AndItemExistsInSet_ThenItemShouldNotBeInSet()
         {
             // Arrange

--- a/src/Tests/CorruptedLoadTests.cs
+++ b/src/Tests/CorruptedLoadTests.cs
@@ -38,9 +38,8 @@ namespace Appegy.Storage
 
             CorruptFirstTypeIndex(StoragePath, 999);
 
-            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException);
-
-            action.Should().Throw<KeyLoadFailedException>();
+            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException))
+                .Should().Throw<KeyLoadFailedException>();
         }
 
         [Test]
@@ -91,7 +90,7 @@ namespace Appegy.Storage
 
             using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
 
-            reopened.Keys.Count.Should().Be(1);
+            reopened.Keys.Should().HaveCount(1);
             if (reopened.Has("a"))
             {
                 reopened.Get("a", 0).Should().Be(1);
@@ -129,9 +128,8 @@ namespace Appegy.Storage
 
             CorruptFirstStringValueLength(StoragePath, -2);
 
-            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException);
-
-            action.Should().Throw<KeyLoadFailedException>();
+            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException))
+                .Should().Throw<KeyLoadFailedException>();
         }
 
         [Test]
@@ -145,9 +143,8 @@ namespace Appegy.Storage
                 writer.Write(-1);
             }
 
-            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
-
-            action.Should().Throw<StorageFileCorruptedException>();
+            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore))
+                .Should().Throw<StorageFileCorruptedException>();
         }
 
         [Test]
@@ -159,9 +156,8 @@ namespace Appegy.Storage
                 writer.Write("1.0.0");
             }
 
-            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
-
-            action.Should().Throw<StorageFileCorruptedException>();
+            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore))
+                .Should().Throw<StorageFileCorruptedException>();
         }
 
         [Test]
@@ -175,9 +171,8 @@ namespace Appegy.Storage
 
             DuplicateFirstRecord(StoragePath);
 
-            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
-
-            action.Should().Throw<StorageFileCorruptedException>();
+            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore))
+                .Should().Throw<StorageFileCorruptedException>();
         }
 
         private static void CorruptFirstTypeIndex(string path, int badValue)

--- a/src/Tests/CorruptedLoadTests.cs
+++ b/src/Tests/CorruptedLoadTests.cs
@@ -38,8 +38,9 @@ namespace Appegy.Storage
 
             CorruptFirstTypeIndex(StoragePath, 999);
 
-            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException))
-                .Should().Throw<KeyLoadFailedException>();
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException);
+
+            action.Should().Throw<KeyLoadFailedException>();
         }
 
         [Test]
@@ -90,7 +91,7 @@ namespace Appegy.Storage
 
             using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
 
-            reopened.Keys.Should().HaveCount(1);
+            reopened.Keys.Count.Should().Be(1);
             if (reopened.Has("a"))
             {
                 reopened.Get("a", 0).Should().Be(1);
@@ -128,8 +129,9 @@ namespace Appegy.Storage
 
             CorruptFirstStringValueLength(StoragePath, -2);
 
-            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException))
-                .Should().Throw<KeyLoadFailedException>();
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.ThrowException);
+
+            action.Should().Throw<KeyLoadFailedException>();
         }
 
         [Test]
@@ -143,8 +145,9 @@ namespace Appegy.Storage
                 writer.Write(-1);
             }
 
-            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore))
-                .Should().Throw<StorageFileCorruptedException>();
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            action.Should().Throw<StorageFileCorruptedException>();
         }
 
         [Test]
@@ -156,8 +159,9 @@ namespace Appegy.Storage
                 writer.Write("1.0.0");
             }
 
-            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore))
-                .Should().Throw<StorageFileCorruptedException>();
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            action.Should().Throw<StorageFileCorruptedException>();
         }
 
         [Test]
@@ -171,8 +175,9 @@ namespace Appegy.Storage
 
             DuplicateFirstRecord(StoragePath);
 
-            FluentActions.Invoking(() => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore))
-                .Should().Throw<StorageFileCorruptedException>();
+            Action action = () => BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build(KeyLoadFailedBehaviour.Ignore);
+
+            action.Should().Throw<StorageFileCorruptedException>();
         }
 
         private static void CorruptFirstTypeIndex(string path, int badValue)

--- a/src/Tests/SerializerReadTruncationTests.cs
+++ b/src/Tests/SerializerReadTruncationTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using Appegy.Storage.Serializers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class SerializerReadTruncationTests
+    {
+        [Test]
+        public void StringSerializer_WhenBodyTruncated_ThenThrows()
+        {
+            var data = new byte[] { 10, 0, 0, 0, 1, 2, 3 };
+
+            Action action = () => ReadString(data);
+
+            action.Should().Throw<EndOfStreamException>();
+        }
+
+        [Test]
+        public void CharSerializer_WhenBodyTruncated_ThenThrows()
+        {
+            var data = new byte[] { 1 };
+
+            Action action = () => ReadChar(data);
+
+            action.Should().Throw<EndOfStreamException>();
+        }
+
+        private static void ReadString(byte[] data)
+        {
+            using var stream = new MemoryStream(data);
+            using var reader = new BinaryReader(stream);
+            StringSerializer.Shared.ReadFrom(reader);
+        }
+
+        private static void ReadChar(byte[] data)
+        {
+            using var stream = new MemoryStream(data);
+            using var reader = new BinaryReader(stream);
+            CharSerializer.Shared.ReadFrom(reader);
+        }
+    }
+}

--- a/src/Tests/SerializerReadTruncationTests.cs
+++ b/src/Tests/SerializerReadTruncationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Appegy.Storage.Serializers;
 using FluentAssertions;
@@ -13,9 +12,7 @@ namespace Appegy.Storage
         {
             var data = new byte[] { 10, 0, 0, 0, 1, 2, 3 };
 
-            Action action = () => ReadString(data);
-
-            action.Should().Throw<EndOfStreamException>();
+            FluentActions.Invoking(() => ReadString(data)).Should().Throw<EndOfStreamException>();
         }
 
         [Test]
@@ -23,9 +20,7 @@ namespace Appegy.Storage
         {
             var data = new byte[] { 1 };
 
-            Action action = () => ReadChar(data);
-
-            action.Should().Throw<EndOfStreamException>();
+            FluentActions.Invoking(() => ReadChar(data)).Should().Throw<EndOfStreamException>();
         }
 
         private static void ReadString(byte[] data)

--- a/src/Tests/SerializerReadTruncationTests.cs.meta
+++ b/src/Tests/SerializerReadTruncationTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bf3d788022714bb98aa73591c6e1b653
+timeCreated: 1718628962


### PR DESCRIPTION
StringSerializer/CharSerializer now throw EndOfStreamException on a truncated read instead of silently returning empty/default, so corruption is surfaced via KeyLoadFailedBehaviour. ReactiveSet.Dispose is now idempotent like the other reactive collections.