### PR TITLE
perf: avoid closure allocation in AddRawRecord; add missing coverage

### DIFF
--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -452,7 +452,15 @@ namespace Appegy.Storage
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         private void AddRawRecord(string key, object value, Type valueType)
         {
-            var typeIndex = _supportedTypes.FindIndex(c => c.Type == valueType);
+            var typeIndex = -1;
+            for (var i = 0; i < _supportedTypes.Count; i++)
+            {
+                if (_supportedTypes[i].Type == valueType)
+                {
+                    typeIndex = i;
+                    break;
+                }
+            }
             if (typeIndex == -1)
             {
                 throw new UnregisteredTypeException(valueType);

--- a/src/Tests/ChangeScopeAndFileTests.cs
+++ b/src/Tests/ChangeScopeAndFileTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class ChangeScopeAndFileTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenNestedScopes_ThenAutoSaveDeferredUntilOutermostCloses()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().EnableAutoSaveOnChange().Build();
+            var outer = storage.MultipleChangeScope();
+            var inner = storage.MultipleChangeScope();
+
+            storage.Set("a", 1);
+            inner.Dispose();
+            storage.IsDirty.Should().BeTrue();
+
+            outer.Dispose();
+            storage.IsDirty.Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenAllRemovedAndSaved_ThenFileDeleted()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Set("a", 1);
+            storage.Save();
+            File.Exists(StoragePath).Should().BeTrue();
+
+            storage.RemoveAll();
+            storage.Save();
+
+            File.Exists(StoragePath).Should().BeFalse();
+        }
+    }
+}

--- a/src/Tests/ChangeScopeAndFileTests.cs.meta
+++ b/src/Tests/ChangeScopeAndFileTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7b0a4e0d30484d9b96af2ef3c3ab0721
+timeCreated: 1718628962

--- a/src/Tests/CollectionDisposalOnRemoveTests.cs
+++ b/src/Tests/CollectionDisposalOnRemoveTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class CollectionDisposalOnRemoveTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenKeyWithCollectionRemoved_ThenCollectionDisposed()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SupportListsOf<int>().Build();
+            var list = (ReactiveList<int>)storage.GetListOf<int>("nums");
+
+            storage.Remove("nums");
+
+            list.IsDisposed.Should().BeTrue();
+        }
+
+        [Test]
+        public void WhenRemoveAll_ThenCollectionsDisposed()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SupportListsOf<int>().Build();
+            var list = (ReactiveList<int>)storage.GetListOf<int>("nums");
+
+            storage.RemoveAll();
+
+            list.IsDisposed.Should().BeTrue();
+        }
+    }
+}

--- a/src/Tests/CollectionDisposalOnRemoveTests.cs.meta
+++ b/src/Tests/CollectionDisposalOnRemoveTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a68369047a19494495b47c7889b6a5b1
+timeCreated: 1718628962


### PR DESCRIPTION
AddRawRecord looked up the section with a capturing lambda (a per-call closure allocation); replaced with a plain loop. Adds regression tests: collections are disposed/unsubscribed on Remove and RemoveAll, nested MultipleChangeScope defers auto-save until the outermost scope closes, and saving an empty storage deletes the file.