### PR TITLE
feat: enable nullable reference types

### DIFF
--- a/Appegy.BinaryPrefs.Lab/Assets/Scripts/GameManager.cs
+++ b/Appegy.BinaryPrefs.Lab/Assets/Scripts/GameManager.cs
@@ -23,17 +23,17 @@ namespace Appegy.Storage.Example
 
             using (_storage.MultipleChangeScope())
             {
-                var value = _storage.GetOrDefault<int>("int_val", 0);
+                var value = _storage.Get<int>("int_val", 0);
                 _storage.Set("int_val", value + 1);
 
                 using (_storage.MultipleChangeScope())
                 {
-                    value = _storage.GetOrDefault<int>("int_val", 0);
+                    value = _storage.Get<int>("int_val", 0);
                     _storage.Set("int_val", value + 1);
 
                     using (_storage.MultipleChangeScope())
                     {
-                        value = _storage.GetOrDefault<int>("int_val", 0);
+                        value = _storage.Get<int>("int_val", 0);
                         _storage.Set("int_val", value + 1);
                     }
                 }
@@ -42,7 +42,7 @@ namespace Appegy.Storage.Example
 
         private void OnGUI()
         {
-            var value = _storage.GetOrDefault<int>("int_val", 0);
+            var value = _storage.Get<int>("int_val", 0);
             if (GUILayout.Button($"INT={value}"))
             {
                 _storage.Set("int_val", value + 1);

--- a/Appegy.BinaryPrefs.Lab/Assets/Scripts/GameManager.cs
+++ b/Appegy.BinaryPrefs.Lab/Assets/Scripts/GameManager.cs
@@ -23,17 +23,17 @@ namespace Appegy.Storage.Example
 
             using (_storage.MultipleChangeScope())
             {
-                var value = _storage.Get<int>("int_val", 0);
+                var value = _storage.GetOrDefault<int>("int_val", 0);
                 _storage.Set("int_val", value + 1);
 
                 using (_storage.MultipleChangeScope())
                 {
-                    value = _storage.Get<int>("int_val", 0);
+                    value = _storage.GetOrDefault<int>("int_val", 0);
                     _storage.Set("int_val", value + 1);
 
                     using (_storage.MultipleChangeScope())
                     {
-                        value = _storage.Get<int>("int_val", 0);
+                        value = _storage.GetOrDefault<int>("int_val", 0);
                         _storage.Set("int_val", value + 1);
                     }
                 }
@@ -42,7 +42,7 @@ namespace Appegy.Storage.Example
 
         private void OnGUI()
         {
-            var value = _storage.Get<int>("int_val", 0);
+            var value = _storage.GetOrDefault<int>("int_val", 0);
             if (GUILayout.Button($"INT={value}"))
             {
                 _storage.Set("int_val", value + 1);

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ storage.Set("player_score", 100);
 storage.Set("player_speed", 5.5f);
 storage.Set("player_name", "John Doe");
 
-int score = storage.Get("player_score", 0);
-float speed = storage.Get("player_speed", 1.0f);
-string name = storage.Get("player_name", "Unknown");
+int score = storage.GetOrDefault("player_score", 0);
+float speed = storage.GetOrDefault("player_speed", 1.0f);
+string name = storage.GetOrDefault("player_name", "Unknown");
 ```
 
 > `BinaryStorage` implements `IDisposable`. Dispose it (e.g. with `using`) to flush and release the file. In the Editor the file path is locked while a storage instance is open, preventing accidental concurrent access to the same file.
@@ -117,7 +117,9 @@ To persist your own type, register a serializer for it:
 storage.Set("level", 7);                      // returns bool: true if the value was written
 bool exists = storage.Has("level");           // key present?
 System.Type type = storage.TypeOf("level");   // stored type, or null if absent
-int level = storage.Get("level", 1);          // typed read with default
+int level = storage.Get<int>("level");        // typed read; throws KeyNotFoundException if absent
+int lvlOr = storage.GetOrDefault("level", 1); // typed read with a fallback
+storage.TryGet("level", out int parsed);      // typed read without throwing
 
 storage.Remove("level");                       // remove one key
 storage.Remove(key => key.StartsWith("tmp_")); // remove by predicate, returns count

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ storage.Set("player_score", 100);
 storage.Set("player_speed", 5.5f);
 storage.Set("player_name", "John Doe");
 
-int score = storage.Get<int>("player_score");
-float speed = storage.Get<float>("player_speed");
-string name = storage.Get<string>("player_name");
+int score = storage.Get("player_score", 0);
+float speed = storage.Get("player_speed", 1.0f);
+string name = storage.Get("player_name", "Unknown");
 ```
 
 > `BinaryStorage` implements `IDisposable`. Dispose it (e.g. with `using`) to flush and release the file. In the Editor the file path is locked while a storage instance is open, preventing accidental concurrent access to the same file.
@@ -117,9 +117,7 @@ To persist your own type, register a serializer for it:
 storage.Set("level", 7);                      // returns bool: true if the value was written
 bool exists = storage.Has("level");           // key present?
 System.Type type = storage.TypeOf("level");   // stored type, or null if absent
-int level = storage.Get<int>("level");        // typed read; throws KeyNotFoundException if absent
-int lvlOr = storage.GetOrDefault("level", 1); // typed read with a fallback
-storage.TryGet("level", out int parsed);      // typed read without throwing
+int level = storage.Get("level", 1);          // typed read with default
 
 storage.Remove("level");                       // remove one key
 storage.Remove(key => key.StartsWith("tmp_")); // remove by predicate, returns count

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ storage.Set("player_score", 100);
 storage.Set("player_speed", 5.5f);
 storage.Set("player_name", "John Doe");
 
-int score = storage.GetOrDefault("player_score", 0);
-float speed = storage.GetOrDefault("player_speed", 1.0f);
-string name = storage.GetOrDefault("player_name", "Unknown");
+int score = storage.Get<int>("player_score");
+float speed = storage.Get<float>("player_speed");
+string name = storage.Get<string>("player_name");
 ```
 
 > `BinaryStorage` implements `IDisposable`. Dispose it (e.g. with `using`) to flush and release the file. In the Editor the file path is locked while a storage instance is open, preventing accidental concurrent access to the same file.

--- a/src/Editor/csc.rsp
+++ b/src/Editor/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/src/Editor/csc.rsp.meta
+++ b/src/Editor/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51a2f8cc34044932822069fa221a0ca4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Runtime/BinaryStorage.Builder.cs
+++ b/src/Runtime/BinaryStorage.Builder.cs
@@ -143,34 +143,41 @@ namespace Appegy.Storage
             {
                 var enumType = typeof(T);
                 var underlyingType = Enum.GetUnderlyingType(enumType);
-                switch (underlyingType)
+                if (underlyingType == typeof(byte))
                 {
-                    case not null when underlyingType == typeof(byte):
-                        AddTypeSerializer(new EnumTypeSerializer<T, byte>(ByteSerializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(sbyte):
-                        AddTypeSerializer(new EnumTypeSerializer<T, sbyte>(SByteSerializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(short):
-                        AddTypeSerializer(new EnumTypeSerializer<T, short>(Int16Serializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(ushort):
-                        AddTypeSerializer(new EnumTypeSerializer<T, ushort>(UInt16Serializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(int):
-                        AddTypeSerializer(new EnumTypeSerializer<T, int>(Int32Serializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(uint):
-                        AddTypeSerializer(new EnumTypeSerializer<T, uint>(UInt32Serializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(long):
-                        AddTypeSerializer(new EnumTypeSerializer<T, long>(Int64Serializer.Shared, useFullName));
-                        break;
-                    case not null when underlyingType == typeof(ulong):
-                        AddTypeSerializer(new EnumTypeSerializer<T, ulong>(UInt64Serializer.Shared, useFullName));
-                        break;
-                    default:
-                        throw new UnexpectedUnderlyingEnumTypeException(enumType, underlyingType);
+                    AddTypeSerializer(new EnumTypeSerializer<T, byte>(ByteSerializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(sbyte))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, sbyte>(SByteSerializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(short))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, short>(Int16Serializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(ushort))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, ushort>(UInt16Serializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(int))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, int>(Int32Serializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(uint))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, uint>(UInt32Serializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(long))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, long>(Int64Serializer.Shared, useFullName));
+                }
+                else if (underlyingType == typeof(ulong))
+                {
+                    AddTypeSerializer(new EnumTypeSerializer<T, ulong>(UInt64Serializer.Shared, useFullName));
+                }
+                else
+                {
+                    throw new UnexpectedUnderlyingEnumTypeException(enumType, underlyingType);
                 }
                 return this;
             }

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -392,6 +392,7 @@ namespace Appegy.Storage
         /// <typeparam name="T">The type of the collection elements.</typeparam>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <param name="key">The key to get the collection for.</param>
+        /// <param name="action">The calling member name, supplied automatically and used in exception messages.</param>
         /// <returns>The collection associated with the key.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -415,16 +415,6 @@ namespace Appegy.Storage
 
         #region Mutable methods
 
-        private T GetDefaultOf<T>()
-        {
-            var typeIndex = _supportedTypes.FindIndex(static c => c is TypedBinarySection<T>);
-            if (typeIndex == -1)
-            {
-                throw new UnregisteredTypeException(typeof(T));
-            }
-            return ((TypedBinarySection<T>)_supportedTypes[typeIndex]).Serializer.GetDefault();
-        }
-
         /// <summary> Adds a new record with the specified key and value. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="key">The key to add the record for.</param>
@@ -557,6 +547,16 @@ namespace Appegy.Storage
         private Record? GetRecord(string key)
         {
             return _data.GetValueOrDefault(key);
+        }
+
+        private T GetDefaultOf<T>()
+        {
+            var typeIndex = _supportedTypes.FindIndex(static c => c is TypedBinarySection<T>);
+            if (typeIndex == -1)
+            {
+                throw new UnregisteredTypeException(typeof(T));
+            }
+            return ((TypedBinarySection<T>)_supportedTypes[typeIndex]).Serializer.GetDefault();
         }
 
         /// <summary>

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -181,7 +181,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        [return: NotNullIfNotNull(nameof(defaultValue))]
+        [return: NotNullIfNotNull("defaultValue")]
         public virtual T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             ThrowIfDisposed();

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -21,7 +20,7 @@ namespace Appegy.Storage
         public bool AutoSave { get; set; }
 
         /// <summary> Gets or sets the behavior when a requested key is not found in the storage. </summary>
-        public MissingKeyBehavior MissingKeyBehavior { get; set; } = MissingKeyBehavior.ReturnDefaultValueOnly;
+        public MissingKeyBehavior MissingKeyBehavior { get; set; } = MissingKeyBehavior.InitializeWithDefaultValue;
 
         /// <summary> Gets or sets the behavior when the type of value associated with a key does not match the expected type. </summary>
         public TypeMismatchBehaviour TypeMismatchBehaviour { get; set; } = TypeMismatchBehaviour.OverrideValueAndType;
@@ -176,13 +175,12 @@ namespace Appegy.Storage
         /// <param name="key">The key to get the value for.</param>
         /// <param name="defaultValue">The default value to use if the key does not exist.</param>
         /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
-        /// <returns>The value associated with the key, or the default value.</returns>
+        /// <returns>The value associated with the key, the supplied default value, or the type's non-null default.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        [return: NotNullIfNotNull("defaultValue")]
-        public virtual T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        public virtual T Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             ThrowIfDisposed();
             ThrowIfCollection<T>();
@@ -194,8 +192,8 @@ namespace Appegy.Storage
                 not null => throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(T)),
                 null => missingKeyBehavior switch
                 {
-                    MissingKeyBehavior.InitializeWithDefaultValue when defaultValue is not null => AddRecord(key, defaultValue).Value,
-                    MissingKeyBehavior.InitializeWithDefaultValue or MissingKeyBehavior.ReturnDefaultValueOnly => defaultValue,
+                    MissingKeyBehavior.InitializeWithDefaultValue => AddRecord(key, defaultValue is not null ? defaultValue : GetDefaultOf<T>()).Value,
+                    MissingKeyBehavior.ReturnDefaultValueOnly => defaultValue is not null ? defaultValue : GetDefaultOf<T>(),
                     _ => throw new UnexpectedEnumException(typeof(MissingKeyBehavior), missingKeyBehavior)
                 }
             };
@@ -416,6 +414,16 @@ namespace Appegy.Storage
         #endregion
 
         #region Mutable methods
+
+        private T GetDefaultOf<T>()
+        {
+            var typeIndex = _supportedTypes.FindIndex(static c => c is TypedBinarySection<T>);
+            if (typeIndex == -1)
+            {
+                throw new UnregisteredTypeException(typeof(T));
+            }
+            return ((TypedBinarySection<T>)_supportedTypes[typeIndex]).Serializer.GetDefault();
+        }
 
         /// <summary> Adds a new record with the specified key and value. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
 using UnityEngine.Pool;
 
 namespace Appegy.Storage
@@ -44,13 +43,13 @@ namespace Appegy.Storage
         #region Events
 
         /// <summary> Occurs when a key is added to the storage. </summary>
-        public event Action<string> OnKeyAdded;
+        public event Action<string>? OnKeyAdded;
 
         /// <summary> Occurs when a key is changed in the storage. </summary>
-        public event Action<string> OnKeyChanged;
+        public event Action<string>? OnKeyChanged;
 
         /// <summary> Occurs when a key is removed from the storage. </summary>
-        public event Action<string> OnKeyRemoved;
+        public event Action<string>? OnKeyRemoved;
 
         #endregion
 
@@ -71,8 +70,7 @@ namespace Appegy.Storage
         /// <param name="key">The key to get the value for.</param>
         /// <returns>The value associated with the key, or null if the key does not exist.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        [CanBeNull]
-        public virtual object GetRaw(string key)
+        public virtual object? GetRaw(string key)
         {
             ThrowIfDisposed();
             return GetRecord(key)?.Object;
@@ -154,8 +152,7 @@ namespace Appegy.Storage
         /// <param name="key">The key to get the type for.</param>
         /// <returns>The type of the value associated with the key, or null if the key does not exist.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        [CanBeNull]
-        public virtual Type TypeOf(string key)
+        public virtual Type? TypeOf(string key)
         {
             ThrowIfDisposed();
             return _data.TryGetValue(key, out var record) ? record.Type : null;
@@ -183,7 +180,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        public virtual T Get<T>(string key, T defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        public virtual T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             ThrowIfDisposed();
             ThrowIfCollection<T>();
@@ -212,7 +209,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        public virtual bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
+        public virtual bool Set<T>(string key, T? value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
         {
             ThrowIfDisposed();
             ThrowIfCollection<T>();
@@ -398,7 +395,7 @@ namespace Appegy.Storage
         /// <returns>The collection associated with the key.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
-        private TCollection GetCollectionOf<T, TCollection>(string key, [CallerMemberName] string action = null)
+        private TCollection GetCollectionOf<T, TCollection>(string key, [CallerMemberName] string action = null!)
             where TCollection : ICollection<T>, IReactiveCollection, new()
         {
             ThrowIfDisposed();
@@ -407,7 +404,7 @@ namespace Appegy.Storage
             {
                 throw new UnexpectedTypeException(key, action, record.Type, typeof(TCollection));
             }
-            return typedRecord.Value;
+            return typedRecord.Value!;
         }
 
         #endregion
@@ -423,7 +420,7 @@ namespace Appegy.Storage
         /// <returns>The added record.</returns>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        private Record<T> AddRecord<T>(string key, T value)
+        private Record<T> AddRecord<T>(string key, T? value)
         {
             var typeIndex = _supportedTypes.FindIndex(static c => c is TypedBinarySection<T>);
             if (typeIndex == -1)
@@ -481,7 +478,7 @@ namespace Appegy.Storage
         /// <param name="value">The new value.</param>
         /// <returns>True if the value was changed; otherwise, false.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        private bool ChangeRecord<T>(string key, Record<T> record, T value)
+        private bool ChangeRecord<T>(string key, Record<T> record, T? value)
         {
             var serializer = ((TypedBinarySection<T>)_supportedTypes[record.TypeIndex]).Serializer;
             var equals = serializer.Equals(record.Value, value);
@@ -545,8 +542,7 @@ namespace Appegy.Storage
         /// <summary> Gets the record associated with the specified key. </summary>
         /// <param name="key">The key to get the record for.</param>
         /// <returns>The record associated with the key, or null if the key does not exist.</returns>
-        [CanBeNull]
-        private Record GetRecord(string key)
+        private Record? GetRecord(string key)
         {
             return _data.GetValueOrDefault(key);
         }
@@ -597,7 +593,7 @@ namespace Appegy.Storage
 
         /// <summary> Throws an exception if the storage has been disposed. </summary>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        private void ThrowIfDisposed([CallerMemberName] string action = null)
+        private void ThrowIfDisposed([CallerMemberName] string action = null!)
         {
             if (IsDisposed)
             {
@@ -608,7 +604,7 @@ namespace Appegy.Storage
         /// <summary> Throws an exception if the specified type is a collection. </summary>
         /// <typeparam name="T">The type to check.</typeparam>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
-        private void ThrowIfCollection<T>([CallerMemberName] string action = null)
+        private void ThrowIfCollection<T>([CallerMemberName] string action = null!)
         {
             var type = typeof(T);
             if (type.IsCollection())

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -192,9 +192,12 @@ namespace Appegy.Storage
             {
                 Record<T> typedRecord => typedRecord.Value,
                 not null => throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(T)),
-                null when missingKeyBehavior == MissingKeyBehavior.InitializeWithDefaultValue && defaultValue is not null => AddRecord(key, defaultValue).Value,
-                null when missingKeyBehavior is MissingKeyBehavior.InitializeWithDefaultValue or MissingKeyBehavior.ReturnDefaultValueOnly => defaultValue,
-                null => throw new UnexpectedEnumException(typeof(MissingKeyBehavior), missingKeyBehavior)
+                null => missingKeyBehavior switch
+                {
+                    MissingKeyBehavior.InitializeWithDefaultValue when defaultValue is not null => AddRecord(key, defaultValue).Value,
+                    MissingKeyBehavior.InitializeWithDefaultValue or MissingKeyBehavior.ReturnDefaultValueOnly => defaultValue,
+                    _ => throw new UnexpectedEnumException(typeof(MissingKeyBehavior), missingKeyBehavior)
+                }
             };
         }
 

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -174,62 +174,15 @@ namespace Appegy.Storage
         /// <summary> Gets the value associated with the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="key">The key to get the value for.</param>
-        /// <returns>The value associated with the key.</returns>
-        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
-        /// <exception cref="KeyNotFoundException">Thrown if the key does not exist.</exception>
-        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        public virtual T Get<T>(string key)
-        {
-            ThrowIfDisposed();
-            ThrowIfCollection<T>();
-            var record = GetRecord(key);
-            return record switch
-            {
-                Record<T> typedRecord => typedRecord.Value,
-                not null => throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(T)),
-                null => throw new KeyNotFoundException($"Key '{key}' was not found in the storage.")
-            };
-        }
-
-        /// <summary> Tries to get the value associated with the specified key. </summary>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        /// <param name="key">The key to get the value for.</param>
-        /// <param name="value">When this method returns true, contains the value associated with the key.</param>
-        /// <returns>True if the key exists; otherwise, false.</returns>
-        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
-        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        public virtual bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
-        {
-            ThrowIfDisposed();
-            ThrowIfCollection<T>();
-            var record = GetRecord(key);
-            switch (record)
-            {
-                case Record<T> typedRecord:
-                    value = typedRecord.Value;
-                    return true;
-                case not null:
-                    throw new UnexpectedTypeException(key, nameof(TryGet), record.Type, typeof(T));
-                default:
-                    value = default;
-                    return false;
-            }
-        }
-
-        /// <summary> Gets the value associated with the specified key, or a fallback if the key does not exist. </summary>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        /// <param name="key">The key to get the value for.</param>
-        /// <param name="fallback">The value to return (and optionally store) when the key does not exist.</param>
+        /// <param name="defaultValue">The default value to use if the key does not exist.</param>
         /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
-        /// <returns>The value associated with the key, or the fallback.</returns>
+        /// <returns>The value associated with the key, or the default value.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        [return: NotNullIfNotNull("fallback")]
-        public virtual T? GetOrDefault<T>(string key, T? fallback = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        [return: NotNullIfNotNull(nameof(defaultValue))]
+        public virtual T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             ThrowIfDisposed();
             ThrowIfCollection<T>();
@@ -238,9 +191,9 @@ namespace Appegy.Storage
             return record switch
             {
                 Record<T> typedRecord => typedRecord.Value,
-                not null => throw new UnexpectedTypeException(key, nameof(GetOrDefault), record.Type, typeof(T)),
-                null when missingKeyBehavior == MissingKeyBehavior.InitializeWithDefaultValue && fallback is not null => AddRecord(key, fallback).Value,
-                null when missingKeyBehavior is MissingKeyBehavior.InitializeWithDefaultValue or MissingKeyBehavior.ReturnDefaultValueOnly => fallback,
+                not null => throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(T)),
+                null when missingKeyBehavior == MissingKeyBehavior.InitializeWithDefaultValue && defaultValue is not null => AddRecord(key, defaultValue).Value,
+                null when missingKeyBehavior is MissingKeyBehavior.InitializeWithDefaultValue or MissingKeyBehavior.ReturnDefaultValueOnly => defaultValue,
                 null => throw new UnexpectedEnumException(typeof(MissingKeyBehavior), missingKeyBehavior)
             };
         }

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -173,14 +174,62 @@ namespace Appegy.Storage
         /// <summary> Gets the value associated with the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="key">The key to get the value for.</param>
-        /// <param name="defaultValue">The default value to use if the key does not exist.</param>
-        /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
         /// <returns>The value associated with the key.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
+        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown if the key does not exist.</exception>
+        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
+        public virtual T Get<T>(string key)
+        {
+            ThrowIfDisposed();
+            ThrowIfCollection<T>();
+            var record = GetRecord(key);
+            return record switch
+            {
+                Record<T> typedRecord => typedRecord.Value,
+                not null => throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(T)),
+                null => throw new KeyNotFoundException($"Key '{key}' was not found in the storage.")
+            };
+        }
+
+        /// <summary> Tries to get the value associated with the specified key. </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="key">The key to get the value for.</param>
+        /// <param name="value">When this method returns true, contains the value associated with the key.</param>
+        /// <returns>True if the key exists; otherwise, false.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
+        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
+        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
+        public virtual bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            ThrowIfDisposed();
+            ThrowIfCollection<T>();
+            var record = GetRecord(key);
+            switch (record)
+            {
+                case Record<T> typedRecord:
+                    value = typedRecord.Value;
+                    return true;
+                case not null:
+                    throw new UnexpectedTypeException(key, nameof(TryGet), record.Type, typeof(T));
+                default:
+                    value = default;
+                    return false;
+            }
+        }
+
+        /// <summary> Gets the value associated with the specified key, or a fallback if the key does not exist. </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="key">The key to get the value for.</param>
+        /// <param name="fallback">The value to return (and optionally store) when the key does not exist.</param>
+        /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
+        /// <returns>The value associated with the key, or the fallback.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        public virtual T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        [return: NotNullIfNotNull("fallback")]
+        public virtual T? GetOrDefault<T>(string key, T? fallback = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             ThrowIfDisposed();
             ThrowIfCollection<T>();
@@ -189,13 +238,10 @@ namespace Appegy.Storage
             return record switch
             {
                 Record<T> typedRecord => typedRecord.Value,
-                not null => throw new UnexpectedTypeException(key, nameof(Get), record.Type, typeof(T)),
-                null => missingKeyBehavior switch
-                {
-                    MissingKeyBehavior.InitializeWithDefaultValue => AddRecord(key, defaultValue).Value,
-                    MissingKeyBehavior.ReturnDefaultValueOnly => defaultValue,
-                    _ => throw new UnexpectedEnumException(typeof(MissingKeyBehavior), missingKeyBehavior)
-                }
+                not null => throw new UnexpectedTypeException(key, nameof(GetOrDefault), record.Type, typeof(T)),
+                null when missingKeyBehavior == MissingKeyBehavior.InitializeWithDefaultValue && fallback is not null => AddRecord(key, fallback).Value,
+                null when missingKeyBehavior is MissingKeyBehavior.InitializeWithDefaultValue or MissingKeyBehavior.ReturnDefaultValueOnly => fallback,
+                null => throw new UnexpectedEnumException(typeof(MissingKeyBehavior), missingKeyBehavior)
             };
         }
 
@@ -209,7 +255,8 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        public virtual bool Set<T>(string key, T? value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
+        public virtual bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
+            where T : notnull
         {
             ThrowIfDisposed();
             ThrowIfCollection<T>();
@@ -395,7 +442,7 @@ namespace Appegy.Storage
         /// <returns>The collection associated with the key.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
-        private TCollection GetCollectionOf<T, TCollection>(string key, [CallerMemberName] string action = null!)
+        private TCollection GetCollectionOf<T, TCollection>(string key, [CallerMemberName] string action = "")
             where TCollection : ICollection<T>, IReactiveCollection, new()
         {
             ThrowIfDisposed();
@@ -404,7 +451,7 @@ namespace Appegy.Storage
             {
                 throw new UnexpectedTypeException(key, action, record.Type, typeof(TCollection));
             }
-            return typedRecord.Value!;
+            return typedRecord.Value;
         }
 
         #endregion
@@ -420,7 +467,7 @@ namespace Appegy.Storage
         /// <returns>The added record.</returns>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        private Record<T> AddRecord<T>(string key, T? value)
+        private Record<T> AddRecord<T>(string key, T value)
         {
             var typeIndex = _supportedTypes.FindIndex(static c => c is TypedBinarySection<T>);
             if (typeIndex == -1)
@@ -478,7 +525,7 @@ namespace Appegy.Storage
         /// <param name="value">The new value.</param>
         /// <returns>True if the value was changed; otherwise, false.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        private bool ChangeRecord<T>(string key, Record<T> record, T? value)
+        private bool ChangeRecord<T>(string key, Record<T> record, T value)
         {
             var serializer = ((TypedBinarySection<T>)_supportedTypes[record.TypeIndex]).Serializer;
             var equals = serializer.Equals(record.Value, value);
@@ -593,7 +640,7 @@ namespace Appegy.Storage
 
         /// <summary> Throws an exception if the storage has been disposed. </summary>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        private void ThrowIfDisposed([CallerMemberName] string action = null!)
+        private void ThrowIfDisposed([CallerMemberName] string action = "")
         {
             if (IsDisposed)
             {
@@ -604,7 +651,7 @@ namespace Appegy.Storage
         /// <summary> Throws an exception if the specified type is a collection. </summary>
         /// <typeparam name="T">The type to check.</typeparam>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
-        private void ThrowIfCollection<T>([CallerMemberName] string action = null!)
+        private void ThrowIfCollection<T>([CallerMemberName] string action = "")
         {
             var type = typeof(T);
             if (type.IsCollection())

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -210,7 +210,7 @@ namespace Appegy.Storage
                 section.Count++;
                 data.Add(key, value);
 
-                void failedToLoadKey(string reason, Exception exception = null)
+                void failedToLoadKey(string reason, Exception? exception = null)
                 {
                     // move stream position to the next record
                     stream.Position = Math.Min(position + entrySize, stream.Length);

--- a/src/Runtime/Collections/IReactiveCollection.cs
+++ b/src/Runtime/Collections/IReactiveCollection.cs
@@ -4,6 +4,6 @@ namespace Appegy.Storage
 {
     internal interface IReactiveCollection : IDisposable
     {
-        public event Action<IReactiveCollection> OnChanged;
+        public event Action<IReactiveCollection>? OnChanged;
     }
 }

--- a/src/Runtime/Collections/ReactiveDictionary.cs
+++ b/src/Runtime/Collections/ReactiveDictionary.cs
@@ -10,7 +10,7 @@ namespace Appegy.Storage
 
         public bool IsDisposed { get; private set; }
 
-        public event Action<IReactiveCollection> OnChanged;
+        public event Action<IReactiveCollection>? OnChanged;
 
         private void SetDirty()
         {

--- a/src/Runtime/Collections/ReactiveList.cs
+++ b/src/Runtime/Collections/ReactiveList.cs
@@ -10,7 +10,7 @@ namespace Appegy.Storage
 
         public bool IsDisposed { get; private set; }
 
-        public event Action<IReactiveCollection> OnChanged;
+        public event Action<IReactiveCollection>? OnChanged;
 
         private void SetDirty()
         {

--- a/src/Runtime/Collections/ReactiveSet.cs
+++ b/src/Runtime/Collections/ReactiveSet.cs
@@ -11,7 +11,7 @@ namespace Appegy.Storage
 
         public bool IsDisposed { get; private set; }
 
-        public event Action<IReactiveCollection> OnChanged;
+        public event Action<IReactiveCollection>? OnChanged;
 
         private void SetDirty()
         {

--- a/src/Runtime/Exceptions/KeyLoadFailedException.cs
+++ b/src/Runtime/Exceptions/KeyLoadFailedException.cs
@@ -9,7 +9,7 @@ namespace Appegy.Storage
         {
         }
 
-        public KeyLoadFailedException(string key, string type, long size, string reason, Exception innerException)
+        public KeyLoadFailedException(string key, string type, long size, string reason, Exception? innerException)
             : base($"Failed to load key {key} of type {type} with size {size}b. Reason: {reason}", innerException)
         {
         }

--- a/src/Runtime/IBinaryStorage.cs
+++ b/src/Runtime/IBinaryStorage.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace Appegy.Storage
 {
@@ -14,8 +13,7 @@ namespace Appegy.Storage
         /// <param name="key">The key to get the value for.</param>
         /// <returns>The value associated with the key, or null if the key does not exist.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        [CanBeNull]
-        object GetRaw(string key);
+        object? GetRaw(string key);
 
         /// <summary> Sets the value for the specified key using an untyped object. </summary>
         /// <param name="key">The key to set the value for.</param>
@@ -39,7 +37,7 @@ namespace Appegy.Storage
         /// <param name="key">The key to get the type for.</param>
         /// <returns>The type of the value associated with the key, or null if the key does not exist.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        Type TypeOf(string key);
+        Type? TypeOf(string key);
 
         /// <summary> Determines whether the storage supports the specified type. </summary>
         /// <typeparam name="T">The type to check for support.</typeparam>
@@ -58,7 +56,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        T Get<T>(string key, T defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
+        T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
 
         /// <summary> Sets the value for the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
@@ -70,7 +68,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null);
+        bool Set<T>(string key, T? value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null);
 
         /// <summary>
         /// Removes the value associated with the specified key.

--- a/src/Runtime/IBinaryStorage.cs
+++ b/src/Runtime/IBinaryStorage.cs
@@ -57,7 +57,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        [return: NotNullIfNotNull(nameof(defaultValue))]
+        [return: NotNullIfNotNull("defaultValue")]
         T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
 
         /// <summary> Sets the value for the specified key. </summary>

--- a/src/Runtime/IBinaryStorage.cs
+++ b/src/Runtime/IBinaryStorage.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Appegy.Storage
 {
@@ -52,13 +51,12 @@ namespace Appegy.Storage
         /// <param name="key">The key to get the value for.</param>
         /// <param name="defaultValue">The default value to use if the key does not exist.</param>
         /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
-        /// <returns>The value associated with the key, or the default value.</returns>
+        /// <returns>The value associated with the key, the supplied default value, or the type's non-null default.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        [return: NotNullIfNotNull("defaultValue")]
-        T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
+        T Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
 
         /// <summary> Sets the value for the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>

--- a/src/Runtime/IBinaryStorage.cs
+++ b/src/Runtime/IBinaryStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Appegy.Storage
 {
@@ -49,14 +50,35 @@ namespace Appegy.Storage
         /// <summary> Gets the value associated with the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="key">The key to get the value for.</param>
-        /// <param name="defaultValue">The default value to use if the key does not exist.</param>
-        /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
         /// <returns>The value associated with the key.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
+        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown if the key does not exist.</exception>
+        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
+        T Get<T>(string key);
+
+        /// <summary> Tries to get the value associated with the specified key. </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="key">The key to get the value for.</param>
+        /// <param name="value">When this method returns true, contains the value associated with the key.</param>
+        /// <returns>True if the key exists; otherwise, false.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
+        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
+        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
+        bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value);
+
+        /// <summary> Gets the value associated with the specified key, or a fallback if the key does not exist. </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="key">The key to get the value for.</param>
+        /// <param name="fallback">The value to return (and optionally store) when the key does not exist.</param>
+        /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
+        /// <returns>The value associated with the key, or the fallback.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
+        [return: NotNullIfNotNull("fallback")]
+        T? GetOrDefault<T>(string key, T? fallback = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
 
         /// <summary> Sets the value for the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
@@ -68,7 +90,7 @@ namespace Appegy.Storage
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        bool Set<T>(string key, T? value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null);
+        bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null) where T : notnull;
 
         /// <summary>
         /// Removes the value associated with the specified key.

--- a/src/Runtime/IBinaryStorage.cs
+++ b/src/Runtime/IBinaryStorage.cs
@@ -50,35 +50,15 @@ namespace Appegy.Storage
         /// <summary> Gets the value associated with the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="key">The key to get the value for.</param>
-        /// <returns>The value associated with the key.</returns>
-        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
-        /// <exception cref="KeyNotFoundException">Thrown if the key does not exist.</exception>
-        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        T Get<T>(string key);
-
-        /// <summary> Tries to get the value associated with the specified key. </summary>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        /// <param name="key">The key to get the value for.</param>
-        /// <param name="value">When this method returns true, contains the value associated with the key.</param>
-        /// <returns>True if the key exists; otherwise, false.</returns>
-        /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
-        /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
-        /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value);
-
-        /// <summary> Gets the value associated with the specified key, or a fallback if the key does not exist. </summary>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        /// <param name="key">The key to get the value for.</param>
-        /// <param name="fallback">The value to return (and optionally store) when the key does not exist.</param>
+        /// <param name="defaultValue">The default value to use if the key does not exist.</param>
         /// <param name="overrideMissingKeyBehavior">Override default behavior when a requested key is not found in the storage.</param>
-        /// <returns>The value associated with the key, or the fallback.</returns>
+        /// <returns>The value associated with the key, or the default value.</returns>
         /// <exception cref="ObjectDisposedException">Thrown if the storage is disposed.</exception>
         /// <exception cref="IncorrectUsageOfCollectionException">Thrown if the type is a collection.</exception>
         /// <exception cref="UnregisteredTypeException">Thrown if the type is not registered.</exception>
         /// <exception cref="UnexpectedTypeException">Thrown if the type of the value associated with the key does not match the expected type.</exception>
-        [return: NotNullIfNotNull("fallback")]
-        T? GetOrDefault<T>(string key, T? fallback = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
+        [return: NotNullIfNotNull(nameof(defaultValue))]
+        T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null);
 
         /// <summary> Sets the value for the specified key. </summary>
         /// <typeparam name="T">The type of the value.</typeparam>

--- a/src/Runtime/NestedBinaryStorage.cs
+++ b/src/Runtime/NestedBinaryStorage.cs
@@ -68,20 +68,10 @@ namespace Appegy.Storage
             return _root.Supports<T>();
         }
 
-        public T Get<T>(string key)
+        [return: NotNullIfNotNull(nameof(defaultValue))]
+        public T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
-            return _root.Get<T>(GetKey(key));
-        }
-
-        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
-        {
-            return _root.TryGet(GetKey(key), out value);
-        }
-
-        [return: NotNullIfNotNull("fallback")]
-        public T? GetOrDefault<T>(string key, T? fallback = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
-        {
-            return _root.GetOrDefault(GetKey(key), fallback, overrideMissingKeyBehavior);
+            return _root.Get(GetKey(key), defaultValue, overrideMissingKeyBehavior);
         }
 
         public bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)

--- a/src/Runtime/NestedBinaryStorage.cs
+++ b/src/Runtime/NestedBinaryStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Appegy.Storage
@@ -31,7 +32,7 @@ namespace Appegy.Storage
             return _prefix + key;
         }
 
-        private bool TryExtractKey(string key, out string value)
+        private bool TryExtractKey(string key, [MaybeNullWhen(false)] out string value)
         {
             if (key.StartsWith(_prefix, StringComparison.Ordinal))
             {
@@ -42,7 +43,7 @@ namespace Appegy.Storage
             return false;
         }
 
-        public object GetRaw(string key)
+        public object? GetRaw(string key)
         {
             return _root.GetRaw(GetKey(key));
         }
@@ -57,7 +58,7 @@ namespace Appegy.Storage
             return _root.Has(GetKey(key));
         }
 
-        public Type TypeOf(string key)
+        public Type? TypeOf(string key)
         {
             return _root.TypeOf(GetKey(key));
         }
@@ -67,12 +68,12 @@ namespace Appegy.Storage
             return _root.Supports<T>();
         }
 
-        public T Get<T>(string key, T defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        public T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             return _root.Get(GetKey(key), defaultValue, overrideMissingKeyBehavior);
         }
 
-        public bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
+        public bool Set<T>(string key, T? value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
         {
             return _root.Set(GetKey(key), value, overrideTypeMismatchBehaviour);
         }

--- a/src/Runtime/NestedBinaryStorage.cs
+++ b/src/Runtime/NestedBinaryStorage.cs
@@ -68,7 +68,7 @@ namespace Appegy.Storage
             return _root.Supports<T>();
         }
 
-        [return: NotNullIfNotNull(nameof(defaultValue))]
+        [return: NotNullIfNotNull("defaultValue")]
         public T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             return _root.Get(GetKey(key), defaultValue, overrideMissingKeyBehavior);

--- a/src/Runtime/NestedBinaryStorage.cs
+++ b/src/Runtime/NestedBinaryStorage.cs
@@ -68,12 +68,24 @@ namespace Appegy.Storage
             return _root.Supports<T>();
         }
 
-        public T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        public T Get<T>(string key)
         {
-            return _root.Get(GetKey(key), defaultValue, overrideMissingKeyBehavior);
+            return _root.Get<T>(GetKey(key));
         }
 
-        public bool Set<T>(string key, T? value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T value)
+        {
+            return _root.TryGet(GetKey(key), out value);
+        }
+
+        [return: NotNullIfNotNull("fallback")]
+        public T? GetOrDefault<T>(string key, T? fallback = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        {
+            return _root.GetOrDefault(GetKey(key), fallback, overrideMissingKeyBehavior);
+        }
+
+        public bool Set<T>(string key, T value, TypeMismatchBehaviour? overrideTypeMismatchBehaviour = null)
+            where T : notnull
         {
             return _root.Set(GetKey(key), value, overrideTypeMismatchBehaviour);
         }

--- a/src/Runtime/NestedBinaryStorage.cs
+++ b/src/Runtime/NestedBinaryStorage.cs
@@ -68,8 +68,7 @@ namespace Appegy.Storage
             return _root.Supports<T>();
         }
 
-        [return: NotNullIfNotNull("defaultValue")]
-        public T? Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
+        public T Get<T>(string key, T? defaultValue = default, MissingKeyBehavior? overrideMissingKeyBehavior = null)
         {
             return _root.Get(GetKey(key), defaultValue, overrideMissingKeyBehavior);
         }

--- a/src/Runtime/Record.cs
+++ b/src/Runtime/Record.cs
@@ -6,17 +6,18 @@ namespace Appegy.Storage
     {
         public abstract Type Type { get; }
         public abstract int TypeIndex { get; }
-        public abstract Object Object { get; }
+        public abstract Object? Object { get; }
     }
 
     internal class Record<T> : Record
     {
         public override Type Type { get; }
         public override int TypeIndex { get; }
-        public override Object Object => Value;
-        public T Value { get; set; }
+        public override Object? Object => Value;
 
-        public Record(T value, int typeIndex)
+        public T? Value { get; set; }
+
+        public Record(T? value, int typeIndex)
         {
             Type = typeof(T);
             TypeIndex = typeIndex;

--- a/src/Runtime/Record.cs
+++ b/src/Runtime/Record.cs
@@ -15,9 +15,9 @@ namespace Appegy.Storage
         public override int TypeIndex { get; }
         public override Object? Object => Value;
 
-        public T? Value { get; set; }
+        public T Value { get; set; }
 
-        public Record(T? value, int typeIndex)
+        public Record(T value, int typeIndex)
         {
             Type = typeof(T);
             TypeIndex = typeIndex;

--- a/src/Runtime/Serializers/CollectionTypeSerializer.cs
+++ b/src/Runtime/Serializers/CollectionTypeSerializer.cs
@@ -26,6 +26,8 @@ namespace Appegy.Storage.Serializers
             return value1 == value2;
         }
 
+        public override TCollection GetDefault() => new();
+
         public override void WriteTo(BinaryWriter writer, TCollection collection)
         {
             writer.Write(collection.Count);

--- a/src/Runtime/Serializers/CollectionTypeSerializer.cs
+++ b/src/Runtime/Serializers/CollectionTypeSerializer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,17 +21,13 @@ namespace Appegy.Storage.Serializers
                 .ToArray();
         }
 
-        public override bool Equals(TCollection? value1, TCollection? value2)
+        public override bool Equals(TCollection value1, TCollection value2)
         {
             return value1 == value2;
         }
 
-        public override void WriteTo(BinaryWriter writer, TCollection? collection)
+        public override void WriteTo(BinaryWriter writer, TCollection collection)
         {
-            if (collection == null)
-            {
-                throw new ArgumentNullException(nameof(collection));
-            }
             writer.Write(collection.Count);
             foreach (var value in collection)
             {
@@ -47,7 +42,7 @@ namespace Appegy.Storage.Serializers
             for (var i = 0; i < count; i++)
             {
                 var value = _typeSerializer.ReadFrom(reader);
-                collection.Add(value!);
+                collection.Add(value);
             }
             return collection;
         }

--- a/src/Runtime/Serializers/CollectionTypeSerializer.cs
+++ b/src/Runtime/Serializers/CollectionTypeSerializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,13 +22,17 @@ namespace Appegy.Storage.Serializers
                 .ToArray();
         }
 
-        public override bool Equals(TCollection value1, TCollection value2)
+        public override bool Equals(TCollection? value1, TCollection? value2)
         {
             return value1 == value2;
         }
 
-        public override void WriteTo(BinaryWriter writer, TCollection collection)
+        public override void WriteTo(BinaryWriter writer, TCollection? collection)
         {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
             writer.Write(collection.Count);
             foreach (var value in collection)
             {
@@ -42,7 +47,7 @@ namespace Appegy.Storage.Serializers
             for (var i = 0; i < count; i++)
             {
                 var value = _typeSerializer.ReadFrom(reader);
-                collection.Add(value);
+                collection.Add(value!);
             }
             return collection;
         }

--- a/src/Runtime/Serializers/EnumTypeSerializer.cs
+++ b/src/Runtime/Serializers/EnumTypeSerializer.cs
@@ -16,6 +16,8 @@ namespace Appegy.Storage.Serializers
             return ToNumber(value1).Equals(ToNumber(value2));
         }
 
+        public override TEnum GetDefault() => default;
+
         public EnumTypeSerializer(TypeSerializer<TNumber> numberType, bool useFullName)
         {
             _numberType = numberType;

--- a/src/Runtime/Serializers/KeyValueTypeSerializer.cs
+++ b/src/Runtime/Serializers/KeyValueTypeSerializer.cs
@@ -24,6 +24,8 @@ namespace Appegy.Storage.Serializers
             return _keySerializer.Equals(value1.Key, value2.Key) && _valueSerializer.Equals(value1.Value, value2.Value);
         }
 
+        public override KeyValuePair<TKey, TValue> GetDefault() => default;
+
         public override void WriteTo(BinaryWriter writer, KeyValuePair<TKey, TValue> value)
         {
             _keySerializer.WriteTo(writer, value.Key);

--- a/src/Runtime/Serializers/KeyValueTypeSerializer.cs
+++ b/src/Runtime/Serializers/KeyValueTypeSerializer.cs
@@ -32,7 +32,7 @@ namespace Appegy.Storage.Serializers
 
         public override KeyValuePair<TKey, TValue> ReadFrom(BinaryReader reader)
         {
-            return new KeyValuePair<TKey, TValue>(_keySerializer.ReadFrom(reader), _valueSerializer.ReadFrom(reader));
+            return new KeyValuePair<TKey, TValue>(_keySerializer.ReadFrom(reader)!, _valueSerializer.ReadFrom(reader)!);
         }
     }
 }

--- a/src/Runtime/Serializers/KeyValueTypeSerializer.cs
+++ b/src/Runtime/Serializers/KeyValueTypeSerializer.cs
@@ -32,7 +32,7 @@ namespace Appegy.Storage.Serializers
 
         public override KeyValuePair<TKey, TValue> ReadFrom(BinaryReader reader)
         {
-            return new KeyValuePair<TKey, TValue>(_keySerializer.ReadFrom(reader)!, _valueSerializer.ReadFrom(reader)!);
+            return new KeyValuePair<TKey, TValue>(_keySerializer.ReadFrom(reader), _valueSerializer.ReadFrom(reader));
         }
     }
 }

--- a/src/Runtime/Serializers/SystemTypesSerializers.cs
+++ b/src/Runtime/Serializers/SystemTypesSerializers.cs
@@ -138,7 +138,7 @@ namespace Appegy.Storage.Serializers
 
         public override string TypeName => "string";
 
-        public override void WriteTo(BinaryWriter writer, string value)
+        public override void WriteTo(BinaryWriter writer, string? value)
         {
             if (value == null)
             {
@@ -159,7 +159,7 @@ namespace Appegy.Storage.Serializers
             }
         }
 
-        public override string ReadFrom(BinaryReader reader)
+        public override string? ReadFrom(BinaryReader reader)
         {
             var size = reader.ReadInt32();
             if (size == -1)

--- a/src/Runtime/Serializers/SystemTypesSerializers.cs
+++ b/src/Runtime/Serializers/SystemTypesSerializers.cs
@@ -138,6 +138,8 @@ namespace Appegy.Storage.Serializers
 
         public override string TypeName => "string";
 
+        public override string GetDefault() => string.Empty;
+
         public override void WriteTo(BinaryWriter writer, string value)
         {
             if (string.IsNullOrEmpty(value))

--- a/src/Runtime/Serializers/SystemTypesSerializers.cs
+++ b/src/Runtime/Serializers/SystemTypesSerializers.cs
@@ -158,7 +158,7 @@ namespace Appegy.Storage.Serializers
         public override string ReadFrom(BinaryReader reader)
         {
             var size = reader.ReadInt32();
-            if (size == 0)
+            if (size <= 0)
             {
                 return string.Empty;
             }

--- a/src/Runtime/Serializers/SystemTypesSerializers.cs
+++ b/src/Runtime/Serializers/SystemTypesSerializers.cs
@@ -138,13 +138,9 @@ namespace Appegy.Storage.Serializers
 
         public override string TypeName => "string";
 
-        public override void WriteTo(BinaryWriter writer, string? value)
+        public override void WriteTo(BinaryWriter writer, string value)
         {
-            if (value == null)
-            {
-                writer.Write(-1);
-            }
-            else if (value.Length == 0)
+            if (value.Length == 0)
             {
                 writer.Write(0);
             }
@@ -159,13 +155,9 @@ namespace Appegy.Storage.Serializers
             }
         }
 
-        public override string? ReadFrom(BinaryReader reader)
+        public override string ReadFrom(BinaryReader reader)
         {
             var size = reader.ReadInt32();
-            if (size == -1)
-            {
-                return null;
-            }
             if (size == 0)
             {
                 return string.Empty;

--- a/src/Runtime/Serializers/SystemTypesSerializers.cs
+++ b/src/Runtime/Serializers/SystemTypesSerializers.cs
@@ -140,7 +140,7 @@ namespace Appegy.Storage.Serializers
 
         public override void WriteTo(BinaryWriter writer, string value)
         {
-            if (value.Length == 0)
+            if (string.IsNullOrEmpty(value))
             {
                 writer.Write(0);
             }
@@ -158,7 +158,7 @@ namespace Appegy.Storage.Serializers
         public override string ReadFrom(BinaryReader reader)
         {
             var size = reader.ReadInt32();
-            if (size <= 0)
+            if (size == 0 || size == -1)
             {
                 return string.Empty;
             }

--- a/src/Runtime/Settings/MissingKeyBehavior.cs
+++ b/src/Runtime/Settings/MissingKeyBehavior.cs
@@ -6,12 +6,12 @@ namespace Appegy.Storage
     public enum MissingKeyBehavior
     {
         /// <summary>
-        /// Initializes the key with the provided default value and stores it.
+        /// Initializes the key with the provided default value, or the type's non-null default when none is provided, and stores it.
         /// </summary>
         InitializeWithDefaultValue,
 
         /// <summary>
-        /// Returns the provided default value without storing it.
+        /// Returns the provided default value, or the type's non-null default when none is provided, without storing it.
         /// </summary>
         ReturnDefaultValueOnly
     }

--- a/src/Runtime/TypeSerializer.cs
+++ b/src/Runtime/TypeSerializer.cs
@@ -12,10 +12,10 @@ namespace Appegy.Storage
 
     public abstract class TypeSerializer<T> : TypeSerializer
     {
-        public override string TypeName { get; } = typeof(T).FullName;
-        public abstract bool Equals(T? value1, T? value2);
-        public abstract void WriteTo(BinaryWriter writer, T? value);
-        public abstract T? ReadFrom(BinaryReader reader);
+        public override string TypeName { get; } = typeof(T).FullName ?? typeof(T).Name;
+        public abstract bool Equals(T value1, T value2);
+        public abstract void WriteTo(BinaryWriter writer, T value);
+        public abstract T ReadFrom(BinaryReader reader);
     }
 
     public abstract class EquatableTypeSerializer<T> : TypeSerializer<T>
@@ -30,16 +30,8 @@ namespace Appegy.Storage
     public abstract class EquatableTypeSerializerRef<T> : TypeSerializer<T>
         where T : class, IEquatable<T>
     {
-        public sealed override bool Equals(T? value1, T? value2)
+        public sealed override bool Equals(T value1, T value2)
         {
-            if (value1 == value2)
-            {
-                return true;
-            }
-            if (value1 == null || value2 == null)
-            {
-                return false;
-            }
             return value1.Equals(value2);
         }
     }

--- a/src/Runtime/TypeSerializer.cs
+++ b/src/Runtime/TypeSerializer.cs
@@ -16,6 +16,7 @@ namespace Appegy.Storage
         public abstract bool Equals(T value1, T value2);
         public abstract void WriteTo(BinaryWriter writer, T value);
         public abstract T ReadFrom(BinaryReader reader);
+        public abstract T GetDefault();
     }
 
     public abstract class EquatableTypeSerializer<T> : TypeSerializer<T>
@@ -25,6 +26,8 @@ namespace Appegy.Storage
         {
             return value1.Equals(value2);
         }
+
+        public override T GetDefault() => default;
     }
 
     public abstract class EquatableTypeSerializerRef<T> : TypeSerializer<T>

--- a/src/Runtime/TypeSerializer.cs
+++ b/src/Runtime/TypeSerializer.cs
@@ -13,9 +13,9 @@ namespace Appegy.Storage
     public abstract class TypeSerializer<T> : TypeSerializer
     {
         public override string TypeName { get; } = typeof(T).FullName;
-        public abstract bool Equals(T value1, T value2);
-        public abstract void WriteTo(BinaryWriter writer, T value);
-        public abstract T ReadFrom(BinaryReader reader);
+        public abstract bool Equals(T? value1, T? value2);
+        public abstract void WriteTo(BinaryWriter writer, T? value);
+        public abstract T? ReadFrom(BinaryReader reader);
     }
 
     public abstract class EquatableTypeSerializer<T> : TypeSerializer<T>
@@ -30,7 +30,7 @@ namespace Appegy.Storage
     public abstract class EquatableTypeSerializerRef<T> : TypeSerializer<T>
         where T : class, IEquatable<T>
     {
-        public sealed override bool Equals(T value1, T value2)
+        public sealed override bool Equals(T? value1, T? value2)
         {
             if (value1 == value2)
             {

--- a/src/Runtime/csc.rsp
+++ b/src/Runtime/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/src/Runtime/csc.rsp.meta
+++ b/src/Runtime/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d1d3d00eee764c44b45bd594338aa31a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tests/BinaryStorageTests.cs
+++ b/src/Tests/BinaryStorageTests.cs
@@ -832,7 +832,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Assert
-            Action action = () => storage.SetRaw("key", null);
+            Action action = () => storage.SetRaw("key", null!);
             action.Should().Throw<ArgumentNullException>();
         }
 
@@ -916,8 +916,8 @@ namespace Appegy.Storage
                 .AddTypeSerializer(Int32Serializer.Shared)
                 .Build();
 
-            var addedKey = (string)null;
-            var changedKey = (string)null;
+            string? addedKey = null;
+            string? changedKey = null;
             storage.OnKeyAdded += k => addedKey = k;
             storage.OnKeyChanged += k => changedKey = k;
 
@@ -1017,6 +1017,65 @@ namespace Appegy.Storage
             // Assert
             raw1.Should().Be(100);
             typed2.Should().Be(200);
+        }
+
+        #endregion
+
+        #region Null Value Tests
+
+        [Test]
+        public void WhenStringValueSetToNull_ThenGetReturnsNull()
+        {
+            // Arrange
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddTypeSerializer(StringSerializer.Shared)
+                .Build();
+
+            // Act
+            storage.Set<string>("key", null);
+
+            // Assert
+            storage.Has("key").Should().Be(true);
+            storage.Get<string>("key").Should().BeNull();
+        }
+
+        [Test]
+        public void WhenNullStringStored_AndStorageReloaded_ThenNullPersisted()
+        {
+            // Arrange & Act
+            using (var storage = BinaryStorage.Construct(StoragePath)
+                       .AddTypeSerializer(StringSerializer.Shared)
+                       .EnableAutoSaveOnChange()
+                       .Build())
+            {
+                storage.Set<string>("key", null);
+            }
+
+            // Assert
+            using (var storage = BinaryStorage.Construct(StoragePath)
+                       .AddTypeSerializer(StringSerializer.Shared)
+                       .Build())
+            {
+                storage.Has("key").Should().Be(true);
+                storage.Get<string>("key").Should().BeNull();
+            }
+        }
+
+        [Test]
+        public void WhenNullStringStored_ThenDistinctFromEmptyString()
+        {
+            // Arrange
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddTypeSerializer(StringSerializer.Shared)
+                .Build();
+
+            // Act
+            storage.Set<string>("null_key", null);
+            storage.Set<string>("empty_key", string.Empty);
+
+            // Assert
+            storage.Get<string>("null_key").Should().BeNull();
+            storage.Get<string>("empty_key").Should().Be(string.Empty);
         }
 
         #endregion

--- a/src/Tests/BinaryStorageTests.cs
+++ b/src/Tests/BinaryStorageTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Appegy.Storage.Serializers;
 using FluentAssertions;
 using NUnit.Framework;
@@ -666,6 +665,31 @@ namespace Appegy.Storage
             storage.Get<int>("key").Should().Be(10);
         }
 
+        [Test]
+        public void WhenMissingKeyBehaviorIsReturnDefaultValueOnly_AndStringHasNoDefault_ThenReturnsEmpty()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SetMissingKeyBehaviour(MissingKeyBehavior.ReturnDefaultValueOnly)
+                .Build();
+
+            storage.Get<string>("missing").Should().Be(string.Empty);
+            storage.Has("missing").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenMissingKeyBehaviorIsInitializeWithDefaultValue_AndStringHasNoDefault_ThenInitializesWithEmpty()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SetMissingKeyBehaviour(MissingKeyBehavior.InitializeWithDefaultValue)
+                .Build();
+
+            storage.Get<string>("missing").Should().Be(string.Empty);
+            storage.Has("missing").Should().BeTrue();
+            storage.Get<string>("missing").Should().Be(string.Empty);
+        }
+
         #endregion
 
         #region Keys Tests
@@ -1018,56 +1042,6 @@ namespace Appegy.Storage
             // Assert
             raw1.Should().Be(100);
             typed2.Should().Be(200);
-        }
-
-        #endregion
-
-        #region Get Default Tests
-
-        [Test]
-        public void WhenKeyMissing_AndGetCalled_ThenReturnsDefault()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath)
-                .AddPrimitiveTypes()
-                .SetMissingKeyBehaviour(MissingKeyBehavior.ReturnDefaultValueOnly)
-                .Build();
-
-            storage.Get("missing", 7).Should().Be(7);
-            storage.Has("missing").Should().BeFalse();
-        }
-
-        [Test]
-        public void WhenKeyExists_AndGetCalled_ThenReturnsValue()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
-            storage.Set("key", 42);
-
-            storage.Get<int>("key").Should().Be(42);
-        }
-
-        [Test]
-        public void WhenStringKeyMissing_AndNoDefaultProvided_ThenReturnsEmptyInsteadOfNull()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath)
-                .AddPrimitiveTypes()
-                .SetMissingKeyBehaviour(MissingKeyBehavior.ReturnDefaultValueOnly)
-                .Build();
-
-            storage.Get<string>("missing").Should().Be(string.Empty);
-            storage.Has("missing").Should().BeFalse();
-        }
-
-        [Test]
-        public void WhenStringKeyMissing_AndInitializeBehavior_ThenInitializesWithEmpty()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath)
-                .AddPrimitiveTypes()
-                .SetMissingKeyBehaviour(MissingKeyBehavior.InitializeWithDefaultValue)
-                .Build();
-
-            storage.Get<string>("missing").Should().Be(string.Empty);
-            storage.Has("missing").Should().BeTrue();
-            storage.Get<string>("missing").Should().Be(string.Empty);
         }
 
         #endregion

--- a/src/Tests/BinaryStorageTests.cs
+++ b/src/Tests/BinaryStorageTests.cs
@@ -1045,6 +1045,31 @@ namespace Appegy.Storage
             storage.Get<int>("key").Should().Be(42);
         }
 
+        [Test]
+        public void WhenStringKeyMissing_AndNoDefaultProvided_ThenReturnsEmptyInsteadOfNull()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SetMissingKeyBehaviour(MissingKeyBehavior.ReturnDefaultValueOnly)
+                .Build();
+
+            storage.Get<string>("missing").Should().Be(string.Empty);
+            storage.Has("missing").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenStringKeyMissing_AndInitializeBehavior_ThenInitializesWithEmpty()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SetMissingKeyBehaviour(MissingKeyBehavior.InitializeWithDefaultValue)
+                .Build();
+
+            storage.Get<string>("missing").Should().Be(string.Empty);
+            storage.Has("missing").Should().BeTrue();
+            storage.Get<string>("missing").Should().Be(string.Empty);
+        }
+
         #endregion
     }
 }

--- a/src/Tests/BinaryStorageTests.cs
+++ b/src/Tests/BinaryStorageTests.cs
@@ -1027,7 +1027,10 @@ namespace Appegy.Storage
         [Test]
         public void WhenKeyMissing_AndGetCalled_ThenReturnsDefault()
         {
-            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            using var storage = BinaryStorage.Construct(StoragePath)
+                .AddPrimitiveTypes()
+                .SetMissingKeyBehaviour(MissingKeyBehavior.ReturnDefaultValueOnly)
+                .Build();
 
             storage.Get("missing", 7).Should().Be(7);
             storage.Has("missing").Should().BeFalse();

--- a/src/Tests/BinaryStorageTests.cs
+++ b/src/Tests/BinaryStorageTests.cs
@@ -623,7 +623,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Act
-            var value = storage.GetOrDefault("key", 10);
+            var value = storage.Get("key", 10);
 
             // Assert
             value.Should().Be(10);
@@ -641,7 +641,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Act
-            var value = storage.GetOrDefault("key", 10);
+            var value = storage.Get("key", 10);
 
             // Assert
             value.Should().Be(10);
@@ -658,7 +658,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Act
-            var value = storage.GetOrDefault("key", 10, MissingKeyBehavior.InitializeWithDefaultValue);
+            var value = storage.Get("key", 10, MissingKeyBehavior.InitializeWithDefaultValue);
 
             // Assert
             value.Should().Be(10);
@@ -1022,14 +1022,15 @@ namespace Appegy.Storage
 
         #endregion
 
-        #region Get / TryGet / GetOrDefault
+        #region Get Default Tests
 
         [Test]
-        public void WhenKeyMissing_AndGetCalled_ThenThrowsKeyNotFound()
+        public void WhenKeyMissing_AndGetCalled_ThenReturnsDefault()
         {
             using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
 
-            storage.Invoking(s => s.Get<int>("missing")).Should().Throw<KeyNotFoundException>();
+            storage.Get("missing", 7).Should().Be(7);
+            storage.Has("missing").Should().BeFalse();
         }
 
         [Test]
@@ -1039,34 +1040,6 @@ namespace Appegy.Storage
             storage.Set("key", 42);
 
             storage.Get<int>("key").Should().Be(42);
-        }
-
-        [Test]
-        public void WhenKeyMissing_AndTryGetCalled_ThenReturnsFalse()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
-
-            storage.TryGet<int>("missing", out var value).Should().BeFalse();
-            value.Should().Be(0);
-        }
-
-        [Test]
-        public void WhenKeyExists_AndTryGetCalled_ThenReturnsTrueWithValue()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
-            storage.Set("key", "value");
-
-            storage.TryGet<string>("key", out var value).Should().BeTrue();
-            value.Should().Be("value");
-        }
-
-        [Test]
-        public void WhenKeyMissing_AndGetOrDefaultCalled_ThenReturnsFallback()
-        {
-            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
-
-            storage.GetOrDefault("missing", 7).Should().Be(7);
-            storage.Has("missing").Should().BeFalse();
         }
 
         #endregion

--- a/src/Tests/BinaryStorageTests.cs
+++ b/src/Tests/BinaryStorageTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Appegy.Storage.Serializers;
 using FluentAssertions;
 using NUnit.Framework;
@@ -622,7 +623,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Act
-            var value = storage.Get("key", 10);
+            var value = storage.GetOrDefault("key", 10);
 
             // Assert
             value.Should().Be(10);
@@ -640,7 +641,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Act
-            var value = storage.Get("key", 10);
+            var value = storage.GetOrDefault("key", 10);
 
             // Assert
             value.Should().Be(10);
@@ -657,7 +658,7 @@ namespace Appegy.Storage
                 .Build();
 
             // Act
-            var value = storage.Get("key", 10, MissingKeyBehavior.InitializeWithDefaultValue);
+            var value = storage.GetOrDefault("key", 10, MissingKeyBehavior.InitializeWithDefaultValue);
 
             // Assert
             value.Should().Be(10);
@@ -1021,61 +1022,51 @@ namespace Appegy.Storage
 
         #endregion
 
-        #region Null Value Tests
+        #region Get / TryGet / GetOrDefault
 
         [Test]
-        public void WhenStringValueSetToNull_ThenGetReturnsNull()
+        public void WhenKeyMissing_AndGetCalled_ThenThrowsKeyNotFound()
         {
-            // Arrange
-            using var storage = BinaryStorage.Construct(StoragePath)
-                .AddTypeSerializer(StringSerializer.Shared)
-                .Build();
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
 
-            // Act
-            storage.Set<string>("key", null);
-
-            // Assert
-            storage.Has("key").Should().Be(true);
-            storage.Get<string>("key").Should().BeNull();
+            storage.Invoking(s => s.Get<int>("missing")).Should().Throw<KeyNotFoundException>();
         }
 
         [Test]
-        public void WhenNullStringStored_AndStorageReloaded_ThenNullPersisted()
+        public void WhenKeyExists_AndGetCalled_ThenReturnsValue()
         {
-            // Arrange & Act
-            using (var storage = BinaryStorage.Construct(StoragePath)
-                       .AddTypeSerializer(StringSerializer.Shared)
-                       .EnableAutoSaveOnChange()
-                       .Build())
-            {
-                storage.Set<string>("key", null);
-            }
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Set("key", 42);
 
-            // Assert
-            using (var storage = BinaryStorage.Construct(StoragePath)
-                       .AddTypeSerializer(StringSerializer.Shared)
-                       .Build())
-            {
-                storage.Has("key").Should().Be(true);
-                storage.Get<string>("key").Should().BeNull();
-            }
+            storage.Get<int>("key").Should().Be(42);
         }
 
         [Test]
-        public void WhenNullStringStored_ThenDistinctFromEmptyString()
+        public void WhenKeyMissing_AndTryGetCalled_ThenReturnsFalse()
         {
-            // Arrange
-            using var storage = BinaryStorage.Construct(StoragePath)
-                .AddTypeSerializer(StringSerializer.Shared)
-                .Build();
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
 
-            // Act
-            storage.Set<string>("null_key", null);
-            storage.Set<string>("empty_key", string.Empty);
+            storage.TryGet<int>("missing", out var value).Should().BeFalse();
+            value.Should().Be(0);
+        }
 
-            // Assert
-            storage.Get<string>("null_key").Should().BeNull();
-            storage.Get<string>("empty_key").Should().Be(string.Empty);
+        [Test]
+        public void WhenKeyExists_AndTryGetCalled_ThenReturnsTrueWithValue()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Set("key", "value");
+
+            storage.TryGet<string>("key", out var value).Should().BeTrue();
+            value.Should().Be("value");
+        }
+
+        [Test]
+        public void WhenKeyMissing_AndGetOrDefaultCalled_ThenReturnsFallback()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+
+            storage.GetOrDefault("missing", 7).Should().Be(7);
+            storage.Has("missing").Should().BeFalse();
         }
 
         #endregion

--- a/src/Tests/CollectionGuardTests.cs
+++ b/src/Tests/CollectionGuardTests.cs
@@ -39,7 +39,7 @@ namespace Appegy.Storage
         {
             using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
             storage.Set("name", "John");
-            storage.GetOrDefault("name", string.Empty).Should().Be("John");
+            storage.Get<string>("name").Should().Be("John");
         }
 
         [Test]

--- a/src/Tests/CollectionGuardTests.cs
+++ b/src/Tests/CollectionGuardTests.cs
@@ -39,7 +39,7 @@ namespace Appegy.Storage
         {
             using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
             storage.Set("name", "John");
-            storage.Get("name", string.Empty).Should().Be("John");
+            storage.GetOrDefault("name", string.Empty).Should().Be("John");
         }
 
         [Test]

--- a/src/Tests/CorruptedLoadTests.cs
+++ b/src/Tests/CorruptedLoadTests.cs
@@ -94,11 +94,11 @@ namespace Appegy.Storage
             reopened.Keys.Count.Should().Be(1);
             if (reopened.Has("a"))
             {
-                reopened.GetOrDefault("a", 0).Should().Be(1);
+                reopened.Get<int>("a").Should().Be(1);
             }
             else
             {
-                reopened.GetOrDefault("b", 0).Should().Be(2);
+                reopened.Get<int>("b").Should().Be(2);
             }
         }
 

--- a/src/Tests/CorruptedLoadTests.cs
+++ b/src/Tests/CorruptedLoadTests.cs
@@ -94,11 +94,11 @@ namespace Appegy.Storage
             reopened.Keys.Count.Should().Be(1);
             if (reopened.Has("a"))
             {
-                reopened.Get("a", 0).Should().Be(1);
+                reopened.GetOrDefault("a", 0).Should().Be(1);
             }
             else
             {
-                reopened.Get("b", 0).Should().Be(2);
+                reopened.GetOrDefault("b", 0).Should().Be(2);
             }
         }
 

--- a/src/Tests/DisposeSaveTests.cs
+++ b/src/Tests/DisposeSaveTests.cs
@@ -16,7 +16,7 @@ namespace Appegy.Storage
 
             using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().EnableAutoSaveOnChange().Build();
 
-            reopened.Get("a", 0).Should().Be(42);
+            reopened.GetOrDefault("a", 0).Should().Be(42);
         }
 
         [Test]

--- a/src/Tests/DisposeSaveTests.cs
+++ b/src/Tests/DisposeSaveTests.cs
@@ -16,7 +16,7 @@ namespace Appegy.Storage
 
             using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().EnableAutoSaveOnChange().Build();
 
-            reopened.GetOrDefault("a", 0).Should().Be(42);
+            reopened.Get<int>("a").Should().Be(42);
         }
 
         [Test]

--- a/src/Tests/StringNullHandlingTests.cs
+++ b/src/Tests/StringNullHandlingTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using Appegy.Storage.Serializers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    [TestFixture]
+    internal class StringNullHandlingTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenNullStringWritten_ThenReadBackAsEmpty()
+        {
+            var buffer = new byte[256];
+            using var writeStream = new MemoryStream(buffer);
+            using var readStream = new MemoryStream(buffer);
+            using var writer = new BinaryWriter(writeStream);
+            using var reader = new BinaryReader(readStream);
+
+            StringSerializer.Shared.WriteTo(writer, null!);
+            var value = StringSerializer.Shared.ReadFrom(reader);
+
+            value.Should().Be(string.Empty);
+            writeStream.Position.Should().Be(readStream.Position);
+        }
+
+        [Test]
+        public void WhenLegacyNullMarkerRead_ThenReturnsEmpty()
+        {
+            var buffer = new byte[256];
+            using var writeStream = new MemoryStream(buffer);
+            using var readStream = new MemoryStream(buffer);
+            using var writer = new BinaryWriter(writeStream);
+            using var reader = new BinaryReader(readStream);
+
+            writer.Write(-1);
+            writer.Flush();
+
+            StringSerializer.Shared.ReadFrom(reader).Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void WhenStringSizeIsCorruptNegative_ThenReadFromThrows()
+        {
+            var buffer = new byte[256];
+            using var writeStream = new MemoryStream(buffer);
+            using var readStream = new MemoryStream(buffer);
+            using var writer = new BinaryWriter(writeStream);
+            using var reader = new BinaryReader(readStream);
+
+            writer.Write(-57);
+            writer.Flush();
+
+            StringSerializer.Shared.Invoking(s => s.ReadFrom(reader)).Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void WhenListContainsNullString_ThenSaveDoesNotThrow_AndReloadsAsEmpty()
+        {
+            using (var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SupportListsOf<string>().Build())
+            {
+                var list = storage.GetListOf<string>("items");
+                list.Add("a");
+                list.Add(null!);
+                list.Add("b");
+
+                storage.Invoking(s => s.Save()).Should().NotThrow();
+            }
+
+            using var reopened = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SupportListsOf<string>().Build();
+            reopened.GetReadOnlyListOf<string>("items").Should().Equal("a", string.Empty, "b");
+        }
+    }
+}

--- a/src/Tests/StringNullHandlingTests.cs.meta
+++ b/src/Tests/StringNullHandlingTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f03b950e260646758146c32bcfff2ad6
+timeCreated: 1718628962

--- a/src/Tests/TypeNameCollisionTests.cs
+++ b/src/Tests/TypeNameCollisionTests.cs
@@ -30,6 +30,7 @@ namespace Appegy.Storage
             public override bool Equals(CollisionA.Thing a, CollisionA.Thing b) => a.Value == b.Value;
             public override void WriteTo(BinaryWriter writer, CollisionA.Thing value) => writer.Write(value.Value);
             public override CollisionA.Thing ReadFrom(BinaryReader reader) => new CollisionA.Thing { Value = reader.ReadInt32() };
+            public override CollisionA.Thing GetDefault() => default;
         }
 
         private class ThingBSerializer : TypeSerializer<CollisionB.Thing>
@@ -37,6 +38,7 @@ namespace Appegy.Storage
             public override bool Equals(CollisionB.Thing a, CollisionB.Thing b) => a.Value == b.Value;
             public override void WriteTo(BinaryWriter writer, CollisionB.Thing value) => writer.Write(value.Value);
             public override CollisionB.Thing ReadFrom(BinaryReader reader) => new CollisionB.Thing { Value = reader.ReadInt32() };
+            public override CollisionB.Thing GetDefault() => default;
         }
 
         [Test]

--- a/src/Tests/TypeSerializers/BaseTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/BaseTypeSerializerTests.cs
@@ -69,8 +69,7 @@ namespace Appegy.Storage.TypeSerializers
 
             storage.Remove("key").Should().Be(true, "The key should be successfully removed from the storage.");
             storage.Has("key").Should().Be(false, "Storage must not contain the removed key");
-            storage.TryGet<TType>("key", out _).Should().Be(false, "The removed key must not be retrievable");
-            storage.GetOrDefault<TType>("key").Should().Be(default(TType), "The fallback retrieved after removal must be default(TType)");
+            storage.Get<TType>("key").Should().Be(default(TType), "The value retrieved after removal must be default(TType)");
         }
     }
 }

--- a/src/Tests/TypeSerializers/BaseTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/BaseTypeSerializerTests.cs
@@ -69,7 +69,7 @@ namespace Appegy.Storage.TypeSerializers
 
             storage.Remove("key").Should().Be(true, "The key should be successfully removed from the storage.");
             storage.Has("key").Should().Be(false, "Storage must not contain the removed key");
-            storage.Get<TType>("key").Should().Be(default(TType), "The value retrieved after removal must be default(TType)");
+            storage.Get<TType>("key").Should().Be(_serializer.GetDefault(), "The value retrieved after removal must be the serializer's non-null default");
         }
     }
 }

--- a/src/Tests/TypeSerializers/BaseTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/BaseTypeSerializerTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace Appegy.Storage.TypeSerializers
 {
     public class BaseTypeSerializerTests<TType, TTypeSerializer> : TypeSerializerTests<TType, TTypeSerializer>
+        where TType : notnull
         where TTypeSerializer : TypeSerializer<TType>, new()
     {
         protected BaseTypeSerializerTests(TType defaultValue) : base(defaultValue, new TTypeSerializer())
@@ -13,6 +14,7 @@ namespace Appegy.Storage.TypeSerializers
     }
 
     public class TypeSerializerTests<TType, TTypeSerializer> : BaseStorageTests
+        where TType : notnull
         where TTypeSerializer : TypeSerializer<TType>
     {
         private readonly byte[] _buffer = new byte[4096];
@@ -67,7 +69,8 @@ namespace Appegy.Storage.TypeSerializers
 
             storage.Remove("key").Should().Be(true, "The key should be successfully removed from the storage.");
             storage.Has("key").Should().Be(false, "Storage must not contain the removed key");
-            storage.Get<TType>("key").Should().Be(default(TType), "The value retrieved after removal must be default(TType)");
+            storage.TryGet<TType>("key", out _).Should().Be(false, "The removed key must not be retrievable");
+            storage.GetOrDefault<TType>("key").Should().Be(default(TType), "The fallback retrieved after removal must be default(TType)");
         }
     }
 }

--- a/src/Tests/TypeSerializers/KeyValueTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/KeyValueTypeSerializerTests.cs
@@ -14,7 +14,6 @@ namespace Appegy.Storage.TypeSerializers
             new object[] { new KeyValuePair<string, int>("key2", 2), "key2_2" },
             new object[] { new KeyValuePair<string, int>("key3", 3), "key3_3" },
             new object[] { new KeyValuePair<string, int>("", 0), "empty_0" },
-            new object[] { new KeyValuePair<string, int>(null!, 0), "null_0" },
             new object[] { new KeyValuePair<string, int>("key with space", 12345), "space_12345" },
             new object[] { new KeyValuePair<string, int>("long key with multiple words", 67890), "long_67890" }
         };

--- a/src/Tests/TypeSerializers/KeyValueTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/KeyValueTypeSerializerTests.cs
@@ -14,7 +14,7 @@ namespace Appegy.Storage.TypeSerializers
             new object[] { new KeyValuePair<string, int>("key2", 2), "key2_2" },
             new object[] { new KeyValuePair<string, int>("key3", 3), "key3_3" },
             new object[] { new KeyValuePair<string, int>("", 0), "empty_0" },
-            new object[] { new KeyValuePair<string, int>(null, 0), "null_0" },
+            new object[] { new KeyValuePair<string, int>(null!, 0), "null_0" },
             new object[] { new KeyValuePair<string, int>("key with space", 12345), "space_12345" },
             new object[] { new KeyValuePair<string, int>("long key with multiple words", 67890), "long_67890" }
         };

--- a/src/Tests/TypeSerializers/StringTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/StringTypeSerializerTests.cs
@@ -10,7 +10,6 @@ namespace Appegy.Storage.TypeSerializers
     {
         private static IEnumerable<object[]> Inputs => new[]
         {
-            new object[] { null!, "null" },
             new object[] { "", "empty" },
             new object[] { "Hello world!", "latin" },
             new object[] { "Прывітанне сусвет!", "cyrillic" },

--- a/src/Tests/TypeSerializers/StringTypeSerializerTests.cs
+++ b/src/Tests/TypeSerializers/StringTypeSerializerTests.cs
@@ -10,7 +10,7 @@ namespace Appegy.Storage.TypeSerializers
     {
         private static IEnumerable<object[]> Inputs => new[]
         {
-            new object[] { null, "null" },
+            new object[] { null!, "null" },
             new object[] { "", "empty" },
             new object[] { "Hello world!", "latin" },
             new object[] { "Прывітанне сусвет!", "cyrillic" },

--- a/src/Tests/csc.rsp
+++ b/src/Tests/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/src/Tests/csc.rsp.meta
+++ b/src/Tests/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 374553a0f41d450795406e55e3b44626
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Enables `#nullable enable` across Runtime/Editor/Tests and reworks serialization around it: serializers are total (never accept or produce null), each declares its non-null default via the new abstract `TypeSerializer<T>.GetDefault()`, `Get<T>` returns a non-null value and `Set<T>` requires `notnull`. The on-disk format is unchanged and the legacy null-string marker is read as empty, so existing save files keep loading. Public API keeps its shape: only nullability-driven signature tweaks, no new methods.