### PR TITLE
feat: optional human-readable JSON debug copy of storage

### DIFF
--- a/src/Runtime/BinaryStorage.Builder.cs
+++ b/src/Runtime/BinaryStorage.Builder.cs
@@ -48,6 +48,7 @@ namespace Appegy.Storage
             private readonly string _filePath;
             private readonly List<BinarySection> _serializers = new();
             private bool _autoSave;
+            private bool _saveJsonForDebug;
             private MissingKeyBehavior _missingKeyBehavior = MissingKeyBehavior.InitializeWithDefaultValue;
             private TypeMismatchBehaviour _typeMismatchBehaviour = TypeMismatchBehaviour.ThrowException;
 
@@ -61,6 +62,16 @@ namespace Appegy.Storage
             public Builder EnableAutoSaveOnChange()
             {
                 _autoSave = true;
+                return this;
+            }
+
+            /// <summary> Enables writing a human-readable JSON copy of the storage next to the binary file for debugging. </summary>
+            /// <remarks> The JSON copy is write-only and never loaded back; the binary file remains the only source of truth. Pass a build-type check (for example, a development-build flag) to toggle it without changing the rest of the configuration. </remarks>
+            /// <param name="enabled">Whether the JSON debug copy should be written on each save.</param>
+            /// <returns>The current <see cref="Builder"/> instance for method chaining.</returns>
+            public Builder SaveJsonCopyForDebug(bool enabled = true)
+            {
+                _saveJsonForDebug = enabled;
                 return this;
             }
 
@@ -230,6 +241,7 @@ namespace Appegy.Storage
             {
                 var storage = new BinaryStorage(_filePath, _serializers);
                 storage.AutoSave = _autoSave;
+                storage.SaveJsonCopyForDebug = _saveJsonForDebug;
                 storage.MissingKeyBehavior = _missingKeyBehavior;
                 storage.TypeMismatchBehaviour = _typeMismatchBehaviour;
                 storage.LoadDataFromDisk(keyLoadFailedBehaviour);

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -19,6 +19,9 @@ namespace Appegy.Storage
         /// <summary> Gets or sets a value indicating whether data should be saved automatically. </summary>
         public bool AutoSave { get; set; }
 
+        /// <summary> Gets or sets a value indicating whether a human-readable JSON copy is written next to the binary file on each save. The copy is write-only and never loaded back. </summary>
+        public bool SaveJsonCopyForDebug { get; set; }
+
         /// <summary> Gets or sets the behavior when a requested key is not found in the storage. </summary>
         public MissingKeyBehavior MissingKeyBehavior { get; set; } = MissingKeyBehavior.ReturnDefaultValueOnly;
 
@@ -733,6 +736,17 @@ namespace Appegy.Storage
             ThrowIfDisposed();
             BinaryStorageIO.SaveDataOnDisk(_storageFilePath, _supportedTypes, _data);
             IsDirty = false;
+            if (SaveJsonCopyForDebug)
+            {
+                try
+                {
+                    BinaryStorageIO.SaveJsonCopyOnDisk(_storageFilePath, _data);
+                }
+                catch (Exception exception)
+                {
+                    UnityEngine.Debug.LogWarning($"Failed to save JSON debug copy of '{_storageFilePath}'. Reason: {exception.Message}");
+                }
+            }
         }
 
         #endregion

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -266,6 +266,29 @@ namespace Appegy.Storage
             return -1;
         }
 
+        /// <summary> Save a human-readable JSON copy of the data next to the binary file. The copy is write-only and never loaded back. </summary>
+        /// <param name="storageFilePath"> Path to the binary storage file </param>
+        /// <param name="data"> Dictionary with the data </param>
+        /// <exception cref="IOException"> An I/O error occurred </exception>
+        internal static void SaveJsonCopyOnDisk(string storageFilePath, IReadOnlyDictionary<string, Record> data)
+        {
+            var jsonFilePath = storageFilePath + ".json";
+
+            if (data.Count == 0)
+            {
+                DeleteFileIfExists(jsonFilePath);
+                return;
+            }
+
+            var directoryName = Path.GetDirectoryName(jsonFilePath);
+            if (!string.IsNullOrEmpty(directoryName) && !Directory.Exists(directoryName))
+            {
+                Directory.CreateDirectory(directoryName);
+            }
+
+            File.WriteAllText(jsonFilePath, DebugJsonWriter.ToJson(data), new UTF8Encoding(false));
+        }
+
         private static void DeleteFileIfExists(string filePath)
         {
             if (File.Exists(filePath))

--- a/src/Runtime/DebugJsonWriter.cs
+++ b/src/Runtime/DebugJsonWriter.cs
@@ -1,0 +1,351 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using UnityEngine;
+
+namespace Appegy.Storage
+{
+    internal static class DebugJsonWriter
+    {
+        private const int IndentWidth = 2;
+        private const int MaxDepth = 64;
+
+        private static readonly BindingFlags MemberFlags = BindingFlags.Public | BindingFlags.Instance;
+
+        public static string ToJson(IReadOnlyDictionary<string, Record> data)
+        {
+            var builder = new StringBuilder();
+            var visited = new HashSet<object>(ReferenceComparer.Instance);
+            WriteEntries(builder, ProjectRoot(data), 0, visited);
+            builder.Append('\n');
+            return builder.ToString();
+        }
+
+        private static IEnumerable<KeyValuePair<string, object?>> ProjectRoot(IReadOnlyDictionary<string, Record> data)
+        {
+            foreach (var pair in data)
+            {
+                yield return new KeyValuePair<string, object?>(pair.Key, pair.Value.Object);
+            }
+        }
+
+        private static void WriteValue(StringBuilder builder, object? value, int depth, HashSet<object> visited)
+        {
+            switch (value)
+            {
+                case null:
+                    builder.Append("null");
+                    return;
+                case bool boolean:
+                    builder.Append(boolean ? "true" : "false");
+                    return;
+                case string text:
+                    WriteString(builder, text);
+                    return;
+                case char character:
+                    WriteString(builder, character.ToString());
+                    return;
+                case Enum enumeration:
+                    WriteString(builder, enumeration.ToString());
+                    return;
+                case float single:
+                    WriteFloating(builder, single, float.IsNaN(single) || float.IsInfinity(single), single.ToString("R", CultureInfo.InvariantCulture));
+                    return;
+                case double real:
+                    WriteFloating(builder, real, double.IsNaN(real) || double.IsInfinity(real), real.ToString("R", CultureInfo.InvariantCulture));
+                    return;
+                case sbyte or byte or short or ushort or int or uint or long or ulong or decimal:
+                    builder.Append(((IFormattable)value).ToString(null, CultureInfo.InvariantCulture));
+                    return;
+                case DateTime dateTime:
+                    WriteString(builder, dateTime.ToString("o", CultureInfo.InvariantCulture));
+                    return;
+                case DateTimeOffset dateTimeOffset:
+                    WriteString(builder, dateTimeOffset.ToString("o", CultureInfo.InvariantCulture));
+                    return;
+                case TimeSpan timeSpan:
+                    WriteString(builder, timeSpan.ToString());
+                    return;
+                case Guid guid:
+                    WriteString(builder, guid.ToString());
+                    return;
+                case Vector2 vector2:
+                    WriteEntries(builder, Members(("x", vector2.x), ("y", vector2.y)), depth, visited);
+                    return;
+                case Vector3 vector3:
+                    WriteEntries(builder, Members(("x", vector3.x), ("y", vector3.y), ("z", vector3.z)), depth, visited);
+                    return;
+                case Vector4 vector4:
+                    WriteEntries(builder, Members(("x", vector4.x), ("y", vector4.y), ("z", vector4.z), ("w", vector4.w)), depth, visited);
+                    return;
+                case Quaternion quaternion:
+                    WriteEntries(builder, Members(("x", quaternion.x), ("y", quaternion.y), ("z", quaternion.z), ("w", quaternion.w)), depth, visited);
+                    return;
+                case Vector2Int vector2Int:
+                    WriteEntries(builder, Members(("x", vector2Int.x), ("y", vector2Int.y)), depth, visited);
+                    return;
+                case Vector3Int vector3Int:
+                    WriteEntries(builder, Members(("x", vector3Int.x), ("y", vector3Int.y), ("z", vector3Int.z)), depth, visited);
+                    return;
+            }
+
+            if (TryGetDictionaryEntries(value, out var entries))
+            {
+                WriteEntries(builder, entries, depth, visited);
+                return;
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                WriteArray(builder, enumerable, depth, visited);
+                return;
+            }
+
+            WriteReflected(builder, value, depth, visited);
+        }
+
+        private static void WriteEntries(StringBuilder builder, IEnumerable<KeyValuePair<string, object?>> entries, int depth, HashSet<object> visited)
+        {
+            builder.Append('{');
+            var first = true;
+            foreach (var entry in entries)
+            {
+                AppendSeparator(builder, ref first);
+                Indent(builder, depth + 1);
+                WriteString(builder, entry.Key);
+                builder.Append(": ");
+                WriteValue(builder, entry.Value, depth + 1, visited);
+            }
+            CloseBlock(builder, depth, first, '}');
+        }
+
+        private static void WriteArray(StringBuilder builder, IEnumerable enumerable, int depth, HashSet<object> visited)
+        {
+            builder.Append('[');
+            var first = true;
+            foreach (var item in enumerable)
+            {
+                AppendSeparator(builder, ref first);
+                Indent(builder, depth + 1);
+                WriteValue(builder, item, depth + 1, visited);
+            }
+            CloseBlock(builder, depth, first, ']');
+        }
+
+        private static void WriteReflected(StringBuilder builder, object value, int depth, HashSet<object> visited)
+        {
+            var type = value.GetType();
+            var isReference = !type.IsValueType;
+            if (depth >= MaxDepth || (isReference && !visited.Add(value)))
+            {
+                WriteString(builder, value.ToString());
+                return;
+            }
+            try
+            {
+                var members = CollectMembers(type, value);
+                if (members.Count == 0)
+                {
+                    WriteString(builder, value.ToString());
+                    return;
+                }
+                WriteEntries(builder, members, depth, visited);
+            }
+            finally
+            {
+                if (isReference)
+                {
+                    visited.Remove(value);
+                }
+            }
+        }
+
+        private static List<KeyValuePair<string, object?>> CollectMembers(Type type, object value)
+        {
+            var members = new List<KeyValuePair<string, object?>>();
+            foreach (var field in type.GetFields(MemberFlags))
+            {
+                if (TryReadMember(() => field.GetValue(value), out var fieldValue))
+                {
+                    members.Add(new KeyValuePair<string, object?>(field.Name, fieldValue));
+                }
+            }
+            foreach (var property in type.GetProperties(MemberFlags))
+            {
+                if (!property.CanRead || property.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+                if (TryReadMember(() => property.GetValue(value), out var propertyValue))
+                {
+                    members.Add(new KeyValuePair<string, object?>(property.Name, propertyValue));
+                }
+            }
+            return members;
+        }
+
+        private static bool TryReadMember(Func<object?> getter, out object? result)
+        {
+            try
+            {
+                result = getter();
+                return true;
+            }
+            catch
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        private static bool TryGetDictionaryEntries(object value, out IEnumerable<KeyValuePair<string, object?>> entries)
+        {
+            foreach (var contract in value.GetType().GetInterfaces())
+            {
+                if (!contract.IsGenericType)
+                {
+                    continue;
+                }
+                var definition = contract.GetGenericTypeDefinition();
+                if (definition == typeof(IReadOnlyDictionary<,>) || definition == typeof(IDictionary<,>))
+                {
+                    entries = EnumerateDictionary((IEnumerable)value);
+                    return true;
+                }
+            }
+            entries = Array.Empty<KeyValuePair<string, object?>>();
+            return false;
+        }
+
+        private static IEnumerable<KeyValuePair<string, object?>> EnumerateDictionary(IEnumerable pairs)
+        {
+            PropertyInfo? keyProperty = null;
+            PropertyInfo? valueProperty = null;
+            foreach (var pair in pairs)
+            {
+                if (pair == null)
+                {
+                    continue;
+                }
+                if (keyProperty == null)
+                {
+                    var pairType = pair.GetType();
+                    keyProperty = pairType.GetProperty("Key");
+                    valueProperty = pairType.GetProperty("Value");
+                }
+                var key = keyProperty?.GetValue(pair);
+                var entryValue = valueProperty?.GetValue(pair);
+                yield return new KeyValuePair<string, object?>(key?.ToString() ?? "null", entryValue);
+            }
+        }
+
+        private static void WriteFloating(StringBuilder builder, object value, bool isSpecial, string formatted)
+        {
+            if (isSpecial)
+            {
+                WriteString(builder, value.ToString());
+            }
+            else
+            {
+                builder.Append(formatted);
+            }
+        }
+
+        private static void WriteString(StringBuilder builder, string? text)
+        {
+            if (text == null)
+            {
+                builder.Append("null");
+                return;
+            }
+            builder.Append('"');
+            foreach (var character in text)
+            {
+                switch (character)
+                {
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        if (character < 0x20)
+                        {
+                            builder.Append("\\u").Append(((int)character).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            builder.Append(character);
+                        }
+                        break;
+                }
+            }
+            builder.Append('"');
+        }
+
+        private static void AppendSeparator(StringBuilder builder, ref bool first)
+        {
+            if (!first)
+            {
+                builder.Append(',');
+            }
+            first = false;
+            builder.Append('\n');
+        }
+
+        private static void CloseBlock(StringBuilder builder, int depth, bool empty, char closing)
+        {
+            if (!empty)
+            {
+                builder.Append('\n');
+                Indent(builder, depth);
+            }
+            builder.Append(closing);
+        }
+
+        private static void Indent(StringBuilder builder, int depth)
+        {
+            builder.Append(' ', depth * IndentWidth);
+        }
+
+        private static KeyValuePair<string, object?>[] Members(params (string Key, object? Value)[] items)
+        {
+            var members = new KeyValuePair<string, object?>[items.Length];
+            for (var i = 0; i < items.Length; i++)
+            {
+                members[i] = new KeyValuePair<string, object?>(items[i].Key, items[i].Value);
+            }
+            return members;
+        }
+
+        private sealed class ReferenceComparer : IEqualityComparer<object>
+        {
+            public static readonly ReferenceComparer Instance = new();
+
+            public new bool Equals(object? left, object? right) => ReferenceEquals(left, right);
+
+            public int GetHashCode(object value) => RuntimeHelpers.GetHashCode(value);
+        }
+    }
+}

--- a/src/Runtime/DebugJsonWriter.cs
+++ b/src/Runtime/DebugJsonWriter.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -26,15 +25,15 @@ namespace Appegy.Storage
             return builder.ToString();
         }
 
-        private static IEnumerable<KeyValuePair<string, object?>> ProjectRoot(IReadOnlyDictionary<string, Record> data)
+        private static IEnumerable<KeyValuePair<string, object>> ProjectRoot(IReadOnlyDictionary<string, Record> data)
         {
             foreach (var pair in data)
             {
-                yield return new KeyValuePair<string, object?>(pair.Key, pair.Value.Object);
+                yield return new KeyValuePair<string, object>(pair.Key, pair.Value.Object);
             }
         }
 
-        private static void WriteValue(StringBuilder builder, object? value, int depth, HashSet<object> visited)
+        private static void WriteValue(StringBuilder builder, object value, int depth, HashSet<object> visited)
         {
             switch (value)
             {
@@ -109,7 +108,7 @@ namespace Appegy.Storage
             WriteReflected(builder, value, depth, visited);
         }
 
-        private static void WriteEntries(StringBuilder builder, IEnumerable<KeyValuePair<string, object?>> entries, int depth, HashSet<object> visited)
+        private static void WriteEntries(StringBuilder builder, IEnumerable<KeyValuePair<string, object>> entries, int depth, HashSet<object> visited)
         {
             builder.Append('{');
             var first = true;
@@ -165,14 +164,14 @@ namespace Appegy.Storage
             }
         }
 
-        private static List<KeyValuePair<string, object?>> CollectMembers(Type type, object value)
+        private static List<KeyValuePair<string, object>> CollectMembers(Type type, object value)
         {
-            var members = new List<KeyValuePair<string, object?>>();
+            var members = new List<KeyValuePair<string, object>>();
             foreach (var field in type.GetFields(MemberFlags))
             {
                 if (TryReadMember(() => field.GetValue(value), out var fieldValue))
                 {
-                    members.Add(new KeyValuePair<string, object?>(field.Name, fieldValue));
+                    members.Add(new KeyValuePair<string, object>(field.Name, fieldValue));
                 }
             }
             foreach (var property in type.GetProperties(MemberFlags))
@@ -183,13 +182,13 @@ namespace Appegy.Storage
                 }
                 if (TryReadMember(() => property.GetValue(value), out var propertyValue))
                 {
-                    members.Add(new KeyValuePair<string, object?>(property.Name, propertyValue));
+                    members.Add(new KeyValuePair<string, object>(property.Name, propertyValue));
                 }
             }
             return members;
         }
 
-        private static bool TryReadMember(Func<object?> getter, out object? result)
+        private static bool TryReadMember(Func<object> getter, out object result)
         {
             try
             {
@@ -203,7 +202,7 @@ namespace Appegy.Storage
             }
         }
 
-        private static bool TryGetDictionaryEntries(object value, out IEnumerable<KeyValuePair<string, object?>> entries)
+        private static bool TryGetDictionaryEntries(object value, out IEnumerable<KeyValuePair<string, object>> entries)
         {
             foreach (var contract in value.GetType().GetInterfaces())
             {
@@ -218,14 +217,14 @@ namespace Appegy.Storage
                     return true;
                 }
             }
-            entries = Array.Empty<KeyValuePair<string, object?>>();
+            entries = Array.Empty<KeyValuePair<string, object>>();
             return false;
         }
 
-        private static IEnumerable<KeyValuePair<string, object?>> EnumerateDictionary(IEnumerable pairs)
+        private static IEnumerable<KeyValuePair<string, object>> EnumerateDictionary(IEnumerable pairs)
         {
-            PropertyInfo? keyProperty = null;
-            PropertyInfo? valueProperty = null;
+            PropertyInfo keyProperty = null;
+            PropertyInfo valueProperty = null;
             foreach (var pair in pairs)
             {
                 if (pair == null)
@@ -240,7 +239,7 @@ namespace Appegy.Storage
                 }
                 var key = keyProperty?.GetValue(pair);
                 var entryValue = valueProperty?.GetValue(pair);
-                yield return new KeyValuePair<string, object?>(key?.ToString() ?? "null", entryValue);
+                yield return new KeyValuePair<string, object>(key?.ToString() ?? "null", entryValue);
             }
         }
 
@@ -256,7 +255,7 @@ namespace Appegy.Storage
             }
         }
 
-        private static void WriteString(StringBuilder builder, string? text)
+        private static void WriteString(StringBuilder builder, string text)
         {
             if (text == null)
             {
@@ -329,12 +328,12 @@ namespace Appegy.Storage
             builder.Append(' ', depth * IndentWidth);
         }
 
-        private static KeyValuePair<string, object?>[] Members(params (string Key, object? Value)[] items)
+        private static KeyValuePair<string, object>[] Members(params (string Key, object Value)[] items)
         {
-            var members = new KeyValuePair<string, object?>[items.Length];
+            var members = new KeyValuePair<string, object>[items.Length];
             for (var i = 0; i < items.Length; i++)
             {
-                members[i] = new KeyValuePair<string, object?>(items[i].Key, items[i].Value);
+                members[i] = new KeyValuePair<string, object>(items[i].Key, items[i].Value);
             }
             return members;
         }
@@ -343,7 +342,7 @@ namespace Appegy.Storage
         {
             public static readonly ReferenceComparer Instance = new();
 
-            public new bool Equals(object? left, object? right) => ReferenceEquals(left, right);
+            public new bool Equals(object left, object right) => ReferenceEquals(left, right);
 
             public int GetHashCode(object value) => RuntimeHelpers.GetHashCode(value);
         }

--- a/src/Runtime/DebugJsonWriter.cs.meta
+++ b/src/Runtime/DebugJsonWriter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e78efa73604348af8cd18994618fe210
+timeCreated: 1708258836

--- a/src/Tests/JsonDebugCopyTests.cs
+++ b/src/Tests/JsonDebugCopyTests.cs
@@ -1,0 +1,142 @@
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Appegy.Storage
+{
+    public class JsonDebugCopyTests : BaseStorageTests
+    {
+        private string JsonPath => StoragePath + ".json";
+
+        [SetUp, TearDown]
+        public void CleanJsonBetweenTests()
+        {
+            if (File.Exists(JsonPath))
+            {
+                File.Delete(JsonPath);
+            }
+        }
+
+        [Test]
+        public void WhenDisabled_ThenNoJsonCopyWritten()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Set("a", 1);
+            storage.Save();
+
+            File.Exists(StoragePath).Should().BeTrue();
+            File.Exists(JsonPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenFlagIsFalse_ThenNoJsonCopyWritten()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SaveJsonCopyForDebug(false).Build();
+            storage.Set("a", 1);
+            storage.Save();
+
+            File.Exists(JsonPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenEnabled_ThenJsonCopyWrittenNextToBinary()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SaveJsonCopyForDebug().Build();
+            storage.Set("count", 7);
+            storage.Set("name", "hero");
+            storage.Set("ratio", 0.5f);
+            storage.Set("enabled", true);
+            storage.Save();
+
+            File.Exists(JsonPath).Should().BeTrue();
+            var json = File.ReadAllText(JsonPath);
+            json.Should().Contain("\"count\": 7");
+            json.Should().Contain("\"name\": \"hero\"");
+            json.Should().Contain("\"ratio\": 0.5");
+            json.Should().Contain("\"enabled\": true");
+        }
+
+        [Test]
+        public void WhenStringContainsSpecialCharacters_ThenJsonIsEscaped()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SaveJsonCopyForDebug().Build();
+            storage.Set("quote", "a\"b\\c\nd");
+            storage.Save();
+
+            var json = File.ReadAllText(JsonPath);
+            json.Should().Contain("\"quote\": \"a\\\"b\\\\c\\nd\"");
+        }
+
+        [Test]
+        public void WhenStoringVector3_ThenJsonContainsComponents()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SaveJsonCopyForDebug().Build();
+            storage.Set("position", new Vector3(1f, 2f, 3f));
+            storage.Save();
+
+            var json = File.ReadAllText(JsonPath);
+            json.Should().Contain("\"position\"");
+            json.Should().Contain("\"x\": 1");
+            json.Should().Contain("\"y\": 2");
+            json.Should().Contain("\"z\": 3");
+        }
+
+        [Test]
+        public void WhenStoringList_ThenJsonContainsArray()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SupportListsOf<int>().SaveJsonCopyForDebug().Build();
+            var numbers = storage.GetListOf<int>("numbers");
+            numbers.Add(10);
+            numbers.Add(20);
+            storage.Save();
+
+            var json = File.ReadAllText(JsonPath);
+            json.Should().Contain("\"numbers\": [");
+            json.Should().Contain("10");
+            json.Should().Contain("20");
+        }
+
+        [Test]
+        public void WhenStoringDictionary_ThenJsonContainsObject()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SupportDictionariesOf<string, int>().SaveJsonCopyForDebug().Build();
+            var scores = storage.GetDictionaryOf<string, int>("scores");
+            scores["alice"] = 42;
+            storage.Save();
+
+            var json = File.ReadAllText(JsonPath);
+            json.Should().Contain("\"scores\"");
+            json.Should().Contain("\"alice\": 42");
+        }
+
+        [Test]
+        public void WhenAllRemovedAndSaved_ThenJsonCopyDeleted()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().SaveJsonCopyForDebug().Build();
+            storage.Set("a", 1);
+            storage.Save();
+            File.Exists(JsonPath).Should().BeTrue();
+
+            storage.RemoveAll();
+            storage.Save();
+
+            File.Exists(JsonPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenToggledAtRuntime_ThenJsonCopyFollowsFlag()
+        {
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Set("a", 1);
+            storage.Save();
+            File.Exists(JsonPath).Should().BeFalse();
+
+            storage.SaveJsonCopyForDebug = true;
+            storage.Set("b", 2);
+            storage.Save();
+
+            File.Exists(JsonPath).Should().BeTrue();
+        }
+    }
+}

--- a/src/Tests/JsonDebugCopyTests.cs.meta
+++ b/src/Tests/JsonDebugCopyTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 85a26ac84eb740bbb799fa2c2ebf6926
+timeCreated: 1708258836


### PR DESCRIPTION
Extracted from `ivan/json-debug-copy`, which sat on top of `ivan/nullable-support`. Only the feature commit is here, rebased onto main; the unrelated Unity Lab churn from the original commit was dropped. `DebugJsonWriter.cs` needed a `#nullable enable` header since it was written against the nullable branch and main has no `csc.rsp`.

Writes a `.json` next to the binary file on each save when enabled, off by default. The copy is write-only and never loaded back, so the storage format is untouched. Costs 4-17% extra save time when on, nothing when off.