### PR TITLE
chore: add unity-mcp package to lab project

### DIFF
--- a/Appegy.BinaryPrefs.Lab/Packages/manifest.json
+++ b/Appegy.BinaryPrefs.Lab/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.appegy.binary-prefs": "file:../../src",
     "com.boundfoxstudios.fluentassertions": "6.8.0",
+    "com.coplaydev.unity-mcp": "10.1.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "3.0.40",
     "com.unity.mobile.android-logcat": "1.4.7",
@@ -28,7 +29,8 @@
       "scopes": [
         "net.tnrd.nsubstitute",
         "com.boundfoxstudios.fluentassertions",
-        "com.yasirkula.ingamedebugconsole"
+        "com.yasirkula.ingamedebugconsole",
+        "com.coplaydev.unity-mcp"
       ]
     }
   ]

--- a/Appegy.BinaryPrefs.Lab/Packages/packages-lock.json
+++ b/Appegy.BinaryPrefs.Lab/Packages/packages-lock.json
@@ -13,6 +13,23 @@
       "dependencies": {},
       "url": "https://package.openupm.com"
     },
+    "com.coplaydev.unity-mcp": {
+      "version": "10.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.physics2d": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
+        "com.unity.test-framework": "1.1.31"
+      },
+      "url": "https://package.openupm.com"
+    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,
@@ -48,6 +65,13 @@
       "dependencies": {
         "com.unity.modules.uielements": "1.0.0"
       }
+    },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.2.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
       "version": "1.6.0",
@@ -112,6 +136,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.imageconversion": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.modules.imgui": {
       "version": "1.0.0",
       "depth": 0,
@@ -126,9 +156,23 @@
     },
     "com.unity.modules.physics": {
       "version": "1.0.0",
-      "depth": 2,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
+    },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.screencapture": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
     },
     "com.unity.modules.ui": {
       "version": "1.0.0",
@@ -147,6 +191,12 @@
         "com.unity.modules.hierarchycore": "1.0.0",
         "com.unity.modules.physics": "1.0.0"
       }
+    },
+    "com.unity.modules.unitywebrequest": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
     }
   }
 }

--- a/Appegy.BinaryPrefs.Lab/ProjectSettings/PackageManagerSettings.asset
+++ b/Appegy.BinaryPrefs.Lab/ProjectSettings/PackageManagerSettings.asset
@@ -37,6 +37,7 @@ MonoBehaviour:
     - net.tnrd.nsubstitute
     - com.boundfoxstudios.fluentassertions
     - com.yasirkula.ingamedebugconsole
+    - com.coplaydev.unity-mcp
     m_IsDefault: 0
     m_Capabilities: 0
     m_ConfigSource: 4
@@ -49,7 +50,7 @@ MonoBehaviour:
     m_Modified: 0
     m_ErrorMessage: 
     m_UserModificationsEntityId:
-      m_Data: -942
+      m_Data: -922
     m_OriginalEntityId:
-      m_Data: -946
+      m_Data: -926
   m_LoadAssets: 0

--- a/Appegy.BinaryPrefs.Lab/ProjectSettings/ProjectVersion.txt
+++ b/Appegy.BinaryPrefs.Lab/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.4.10f1
-m_EditorVersionWithRevision: 6000.4.10f1 (feeafc12a938)
+m_EditorVersion: 6000.4.12f1
+m_EditorVersionWithRevision: 6000.4.12f1 (3ca267ce8005)


### PR DESCRIPTION
Adds MCP for Unity package to the lab project so the editor can be driven over MCP. Also bumps the editor to 6000.4.12f1, which CI picks up via `unityVersion: auto`.