### PR TITLE
perf: serialize storage into pooled buffer and write it with one call

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "UnityMCP": {
+      "command": "uv",
+      "args": [
+        "run", "--no-project", "python",
+        "-c", "import os,runpy; runpy.run_path(os.environ['CLAUDE_PROJECT_DIR']+'/tools/unity-mcp.py', run_name='__main__')",
+        "lab"
+      ]
+    }
+  }
+}

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -15,7 +15,6 @@ namespace Appegy.Storage
         private readonly Dictionary<string, Record> _data = new();
         private readonly Dictionary<IReactiveCollection, string> _collections = new();
         private int _changeScopeCounter;
-        private int _saveBufferSizeHint;
 
         /// <summary> Gets or sets a value indicating whether data should be saved automatically. </summary>
         public bool AutoSave { get; set; }
@@ -717,7 +716,7 @@ namespace Appegy.Storage
         private void LoadDataFromDisk(KeyLoadFailedBehaviour keyLoadFailedBehaviour)
         {
             ThrowIfDisposed();
-            _saveBufferSizeHint = BinaryStorageIO.LoadDataFromDisk(_storageFilePath, _supportedTypes, _data, keyLoadFailedBehaviour);
+            BinaryStorageIO.LoadDataFromDisk(_storageFilePath, _supportedTypes, _data, keyLoadFailedBehaviour);
             foreach (var pair in _data)
             {
                 var rc = pair.Value.AsReactiveCollection();
@@ -735,7 +734,7 @@ namespace Appegy.Storage
         private void SaveDataFromDisk()
         {
             ThrowIfDisposed();
-            _saveBufferSizeHint = BinaryStorageIO.SaveDataOnDisk(_storageFilePath, _supportedTypes, _data, _saveBufferSizeHint);
+            BinaryStorageIO.SaveDataOnDisk(_storageFilePath, _supportedTypes, _data);
             IsDirty = false;
             if (SaveJsonCopyForDebug)
             {

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -15,6 +15,7 @@ namespace Appegy.Storage
         private readonly Dictionary<string, Record> _data = new();
         private readonly Dictionary<IReactiveCollection, string> _collections = new();
         private int _changeScopeCounter;
+        private int _saveBufferSizeHint;
 
         /// <summary> Gets or sets a value indicating whether data should be saved automatically. </summary>
         public bool AutoSave { get; set; }
@@ -716,7 +717,7 @@ namespace Appegy.Storage
         private void LoadDataFromDisk(KeyLoadFailedBehaviour keyLoadFailedBehaviour)
         {
             ThrowIfDisposed();
-            BinaryStorageIO.LoadDataFromDisk(_storageFilePath, _supportedTypes, _data, keyLoadFailedBehaviour);
+            _saveBufferSizeHint = BinaryStorageIO.LoadDataFromDisk(_storageFilePath, _supportedTypes, _data, keyLoadFailedBehaviour);
             foreach (var pair in _data)
             {
                 var rc = pair.Value.AsReactiveCollection();
@@ -734,7 +735,7 @@ namespace Appegy.Storage
         private void SaveDataFromDisk()
         {
             ThrowIfDisposed();
-            BinaryStorageIO.SaveDataOnDisk(_storageFilePath, _supportedTypes, _data);
+            _saveBufferSizeHint = BinaryStorageIO.SaveDataOnDisk(_storageFilePath, _supportedTypes, _data, _saveBufferSizeHint);
             IsDirty = false;
             if (SaveJsonCopyForDebug)
             {

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -8,8 +8,6 @@ namespace Appegy.Storage
 {
     internal static class BinaryStorageIO
     {
-        private const int DefaultBufferSize = 1024;
-
         [ThreadStatic] private static PooledMemoryStream _serializationStream;
         [ThreadStatic] private static BinaryWriter _serializationWriter;
 
@@ -17,10 +15,8 @@ namespace Appegy.Storage
         /// <param name="storageFilePath"> Path to the storage file </param>
         /// <param name="sections"> List of sections </param>
         /// <param name="data"> Dictionary to store data </param>
-        /// <param name="bufferSizeHint"> Expected size of the file in bytes, used as initial capacity of the serialization buffer </param>
-        /// <returns> Amount of bytes written, or 0 when the storage was empty and the file was deleted </returns>
         /// <exception cref="IOException"> An I/O error occurred </exception>
-        internal static int SaveDataOnDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data, int bufferSizeHint = 0)
+        internal static void SaveDataOnDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data)
         {
             // make sure there is no temp file from previous (most likely failed) save try
             var storageFilePathTmp = storageFilePath + ".tmp";
@@ -30,7 +26,7 @@ namespace Appegy.Storage
             if (data.Count == 0)
             {
                 DeleteFileIfExists(storageFilePath);
-                return 0;
+                return;
             }
 
             // prepare directory for save
@@ -40,13 +36,11 @@ namespace Appegy.Storage
                 Directory.CreateDirectory(directoryName);
             }
 
-            int length;
-            var buffer = SerializeToBuffer(sections, data, bufferSizeHint);
+            var buffer = SerializeToBuffer(sections, data);
             try
             {
-                length = (int)buffer.Length;
                 using var stream = new FileStream(storageFilePathTmp, FileMode.Create);
-                stream.Write(buffer.GetBuffer(), 0, length);
+                stream.Write(buffer.GetBuffer(), 0, (int)buffer.Length);
             }
             finally
             {
@@ -58,21 +52,19 @@ namespace Appegy.Storage
                 File.Delete(storageFilePath);
             }
             File.Move(storageFilePathTmp, storageFilePath);
-            return length;
         }
 
         /// <summary> Serialize data into a pooled in-memory buffer. Caller owns the returned stream and must call <see cref="PooledMemoryStream.Release"/>. </summary>
         /// <param name="sections"> List of sections </param>
         /// <param name="data"> Dictionary to store data </param>
-        /// <param name="bufferSizeHint"> Expected size of the file in bytes, used as initial capacity of the buffer </param>
         /// <returns> Stream holding the serialized bytes </returns>
-        internal static PooledMemoryStream SerializeToBuffer(IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data, int bufferSizeHint = 0)
+        internal static PooledMemoryStream SerializeToBuffer(IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data)
         {
             _serializationStream ??= new PooledMemoryStream();
             _serializationWriter ??= new BinaryWriter(_serializationStream, Encoding.UTF8);
 
             var stream = _serializationStream;
-            stream.Reset(Math.Max(bufferSizeHint, DefaultBufferSize));
+            stream.Reset();
             try
             {
                 WriteData(_serializationWriter, sections, data);
@@ -134,11 +126,10 @@ namespace Appegy.Storage
         /// <param name="sections"> List of sections </param>
         /// <param name="data"> Dictionary to store data </param>
         /// <param name="keyLoadFailedBehaviour">Specify behaviour for broken keys</param>
-        /// <returns> Size of the loaded file in bytes, or 0 when there was no file </returns>
         /// <exception cref="IOException"> An I/O error occurred </exception>
         /// <exception cref="StorageFileCorruptedException"> The file structure is corrupted (bad header, truncated framing, or a duplicate key). </exception>
         /// <exception cref="KeyLoadFailedException"> A key failed to load and <paramref name="keyLoadFailedBehaviour"/> is <see cref="KeyLoadFailedBehaviour.ThrowException"/>. </exception>
-        internal static int LoadDataFromDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, IDictionary<string, Record> data, KeyLoadFailedBehaviour keyLoadFailedBehaviour)
+        internal static void LoadDataFromDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, IDictionary<string, Record> data, KeyLoadFailedBehaviour keyLoadFailedBehaviour)
         {
             data.Clear();
             foreach (var section in sections)
@@ -147,7 +138,7 @@ namespace Appegy.Storage
             }
             if (!File.Exists(storageFilePath))
             {
-                return 0;
+                return;
             }
             using var stream = new FileStream(storageFilePath, FileMode.Open);
             using var reader = new BinaryReader(stream, Encoding.UTF8);
@@ -274,8 +265,6 @@ namespace Appegy.Storage
                     }
                 }
             }
-
-            return (int)Math.Min(stream.Length, int.MaxValue);
         }
 
         private static BinarySection FindSection(IReadOnlyList<BinarySection> sections, string typeName)

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -8,12 +8,19 @@ namespace Appegy.Storage
 {
     internal static class BinaryStorageIO
     {
+        private const int DefaultBufferSize = 1024;
+
+        [ThreadStatic] private static PooledMemoryStream _serializationStream;
+        [ThreadStatic] private static BinaryWriter _serializationWriter;
+
         /// <summary> Save data from memory to disk. </summary>
         /// <param name="storageFilePath"> Path to the storage file </param>
         /// <param name="sections"> List of sections </param>
         /// <param name="data"> Dictionary to store data </param>
+        /// <param name="bufferSizeHint"> Expected size of the file in bytes, used as initial capacity of the serialization buffer </param>
+        /// <returns> Amount of bytes written, or 0 when the storage was empty and the file was deleted </returns>
         /// <exception cref="IOException"> An I/O error occurred </exception>
-        internal static void SaveDataOnDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, IReadOnlyDictionary<string, Record> data)
+        internal static int SaveDataOnDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data, int bufferSizeHint = 0)
         {
             // make sure there is no temp file from previous (most likely failed) save try
             var storageFilePathTmp = storageFilePath + ".tmp";
@@ -23,7 +30,7 @@ namespace Appegy.Storage
             if (data.Count == 0)
             {
                 DeleteFileIfExists(storageFilePath);
-                return;
+                return 0;
             }
 
             // prepare directory for save
@@ -33,49 +40,17 @@ namespace Appegy.Storage
                 Directory.CreateDirectory(directoryName);
             }
 
-            using (var stream = new FileStream(storageFilePathTmp, FileMode.Create))
+            int length;
+            var buffer = SerializeToBuffer(sections, data, bufferSizeHint);
+            try
             {
-                using var writer = new BinaryWriter(stream, Encoding.UTF8);
-
-                // #01 <---> Store package version at the start of the file
-                writer.Write(PackageInfo.Version);
-
-                // #02 <---> Reserve 8 bytes for future updates
-                writer.Write(0L);
-
-                // #03 <---> Store amount of used serializers
-                writer.Write(sections.Count);
-                foreach (var section in sections)
-                {
-                    // #04 <---> Write only name of serializer type
-                    writer.Write(section.Count > 0 ? section.TypeName : string.Empty);
-                }
-
-                // #05 <---> Store amount of records in storage
-                writer.Write(data.Count);
-                foreach (var entry in data)
-                {
-                    // #06 <---> Write key
-                    writer.Write(entry.Key);
-
-                    // #07 <---> Write type index
-                    writer.Write(entry.Value.TypeIndex);
-
-                    // #08 <---> Keep space for size (will be calculated later)
-                    var position = writer.BaseStream.Position;
-                    writer.Write(0L);
-
-                    // #09 <---> Write value itself
-                    var start = writer.BaseStream.Position;
-                    var serializer = sections[entry.Value.TypeIndex];
-                    serializer.WriteTo(writer, entry.Value);
-                    var entrySize = writer.BaseStream.Position - start;
-
-                    // #08 <---> Write real size of entry
-                    (position, writer.BaseStream.Position) = (writer.BaseStream.Position, position);
-                    writer.Write(entrySize);
-                    (_, writer.BaseStream.Position) = (writer.BaseStream.Position, position);
-                }
+                length = (int)buffer.Length;
+                using var stream = new FileStream(storageFilePathTmp, FileMode.Create);
+                stream.Write(buffer.GetBuffer(), 0, length);
+            }
+            finally
+            {
+                buffer.Release();
             }
 
             if (File.Exists(storageFilePath))
@@ -83,6 +58,75 @@ namespace Appegy.Storage
                 File.Delete(storageFilePath);
             }
             File.Move(storageFilePathTmp, storageFilePath);
+            return length;
+        }
+
+        /// <summary> Serialize data into a pooled in-memory buffer. Caller owns the returned stream and must call <see cref="PooledMemoryStream.Release"/>. </summary>
+        /// <param name="sections"> List of sections </param>
+        /// <param name="data"> Dictionary to store data </param>
+        /// <param name="bufferSizeHint"> Expected size of the file in bytes, used as initial capacity of the buffer </param>
+        /// <returns> Stream holding the serialized bytes </returns>
+        internal static PooledMemoryStream SerializeToBuffer(IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data, int bufferSizeHint = 0)
+        {
+            _serializationStream ??= new PooledMemoryStream();
+            _serializationWriter ??= new BinaryWriter(_serializationStream, Encoding.UTF8);
+
+            var stream = _serializationStream;
+            stream.Reset(Math.Max(bufferSizeHint, DefaultBufferSize));
+            try
+            {
+                WriteData(_serializationWriter, sections, data);
+            }
+            catch
+            {
+                stream.Release();
+                throw;
+            }
+            return stream;
+        }
+
+        private static void WriteData(BinaryWriter writer, IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data)
+        {
+            // #01 <---> Store package version at the start of the file
+            writer.Write(PackageInfo.Version);
+
+            // #02 <---> Reserve 8 bytes for future updates
+            writer.Write(0L);
+
+            // #03 <---> Store amount of used serializers
+            writer.Write(sections.Count);
+            for (var i = 0; i < sections.Count; i++)
+            {
+                // #04 <---> Write only name of serializer type
+                var section = sections[i];
+                writer.Write(section.Count > 0 ? section.TypeName : string.Empty);
+            }
+
+            // #05 <---> Store amount of records in storage
+            writer.Write(data.Count);
+            foreach (var entry in data)
+            {
+                // #06 <---> Write key
+                writer.Write(entry.Key);
+
+                // #07 <---> Write type index
+                writer.Write(entry.Value.TypeIndex);
+
+                // #08 <---> Keep space for size (will be calculated later)
+                var position = writer.BaseStream.Position;
+                writer.Write(0L);
+
+                // #09 <---> Write value itself
+                var start = writer.BaseStream.Position;
+                var serializer = sections[entry.Value.TypeIndex];
+                serializer.WriteTo(writer, entry.Value);
+                var entrySize = writer.BaseStream.Position - start;
+
+                // #08 <---> Write real size of entry
+                (position, writer.BaseStream.Position) = (writer.BaseStream.Position, position);
+                writer.Write(entrySize);
+                (_, writer.BaseStream.Position) = (writer.BaseStream.Position, position);
+            }
         }
 
         /// <summary> Load data from disk to memory. </summary>
@@ -90,10 +134,11 @@ namespace Appegy.Storage
         /// <param name="sections"> List of sections </param>
         /// <param name="data"> Dictionary to store data </param>
         /// <param name="keyLoadFailedBehaviour">Specify behaviour for broken keys</param>
+        /// <returns> Size of the loaded file in bytes, or 0 when there was no file </returns>
         /// <exception cref="IOException"> An I/O error occurred </exception>
         /// <exception cref="StorageFileCorruptedException"> The file structure is corrupted (bad header, truncated framing, or a duplicate key). </exception>
         /// <exception cref="KeyLoadFailedException"> A key failed to load and <paramref name="keyLoadFailedBehaviour"/> is <see cref="KeyLoadFailedBehaviour.ThrowException"/>. </exception>
-        internal static void LoadDataFromDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, IDictionary<string, Record> data, KeyLoadFailedBehaviour keyLoadFailedBehaviour)
+        internal static int LoadDataFromDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, IDictionary<string, Record> data, KeyLoadFailedBehaviour keyLoadFailedBehaviour)
         {
             data.Clear();
             foreach (var section in sections)
@@ -102,7 +147,7 @@ namespace Appegy.Storage
             }
             if (!File.Exists(storageFilePath))
             {
-                return;
+                return 0;
             }
             using var stream = new FileStream(storageFilePath, FileMode.Open);
             using var reader = new BinaryReader(stream, Encoding.UTF8);
@@ -229,6 +274,8 @@ namespace Appegy.Storage
                     }
                 }
             }
+
+            return (int)Math.Min(stream.Length, int.MaxValue);
         }
 
         private static BinarySection FindSection(IReadOnlyList<BinarySection> sections, string typeName)

--- a/src/Runtime/Utilities/PooledMemoryStream.cs
+++ b/src/Runtime/Utilities/PooledMemoryStream.cs
@@ -6,9 +6,11 @@ namespace Appegy.Storage
 {
     internal sealed class PooledMemoryStream : Stream
     {
-        private const int MinimumCapacity = 256;
+        private const int MinimumCapacity = 1024;
+        private const int MaximumRememberedCapacity = 1024 * 1024;
 
         private byte[] _buffer = Array.Empty<byte>();
+        private int _rememberedCapacity = MinimumCapacity;
         private int _position;
         private int _length;
 
@@ -16,16 +18,12 @@ namespace Appegy.Storage
 
         public byte[] GetBuffer() => _buffer;
 
-        public void Reset(int capacity)
+        public void Reset()
         {
-            if (capacity < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Capacity can't be negative.");
-            }
-            if (_buffer.Length < capacity)
+            if (_buffer.Length < _rememberedCapacity)
             {
                 Release();
-                _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(capacity, MinimumCapacity));
+                _buffer = ArrayPool<byte>.Shared.Rent(_rememberedCapacity);
             }
             _position = 0;
             _length = 0;
@@ -33,6 +31,7 @@ namespace Appegy.Storage
 
         public void Release()
         {
+            _rememberedCapacity = Math.Clamp(Math.Max(_rememberedCapacity, _length), MinimumCapacity, MaximumRememberedCapacity);
             if (_buffer.Length > 0)
             {
                 ArrayPool<byte>.Shared.Return(_buffer);

--- a/src/Runtime/Utilities/PooledMemoryStream.cs
+++ b/src/Runtime/Utilities/PooledMemoryStream.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Buffers;
+using System.IO;
+
+namespace Appegy.Storage
+{
+    internal sealed class PooledMemoryStream : Stream
+    {
+        private const int MinimumCapacity = 256;
+
+        private byte[] _buffer = Array.Empty<byte>();
+        private int _position;
+        private int _length;
+
+        public int Capacity => _buffer.Length;
+
+        public byte[] GetBuffer() => _buffer;
+
+        public void Reset(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Capacity can't be negative.");
+            }
+            if (_buffer.Length < capacity)
+            {
+                Release();
+                _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(capacity, MinimumCapacity));
+            }
+            _position = 0;
+            _length = 0;
+        }
+
+        public void Release()
+        {
+            if (_buffer.Length > 0)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = Array.Empty<byte>();
+            }
+            _position = 0;
+            _length = 0;
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => true;
+        public override bool CanWrite => true;
+        public override long Length => _length;
+
+        public override long Position
+        {
+            get => _position;
+            set
+            {
+                if (value < 0 || value > _length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, $"Position must be within [0, {_length}].");
+                }
+                _position = (int)value;
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException($"{nameof(PooledMemoryStream)} is write-only.");
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            Position = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => _length + offset,
+                _ => throw new UnexpectedEnumException(typeof(SeekOrigin), origin)
+            };
+            return _position;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException($"{nameof(PooledMemoryStream)} length is defined by written data.");
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            EnsureCapacity(_position + count);
+            Array.Copy(buffer, offset, _buffer, _position, count);
+            Advance(count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            EnsureCapacity(_position + buffer.Length);
+            buffer.CopyTo(new Span<byte>(_buffer, _position, buffer.Length));
+            Advance(buffer.Length);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            EnsureCapacity(_position + 1);
+            _buffer[_position] = value;
+            Advance(1);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Release();
+            base.Dispose(disposing);
+        }
+
+        private void EnsureCapacity(int required)
+        {
+            if (required < 0)
+            {
+                throw new IOException("Storage is too big to be serialized: buffer would exceed 2 GB.");
+            }
+            if (required <= _buffer.Length)
+            {
+                return;
+            }
+            var doubled = (int)Math.Min((long)_buffer.Length * 2, int.MaxValue);
+            var grown = ArrayPool<byte>.Shared.Rent(Math.Max(Math.Max(required, doubled), MinimumCapacity));
+            Array.Copy(_buffer, grown, _length);
+            if (_buffer.Length > 0)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+            }
+            _buffer = grown;
+        }
+
+        private void Advance(int count)
+        {
+            _position += count;
+            if (_position > _length)
+            {
+                _length = _position;
+            }
+        }
+    }
+}

--- a/src/Runtime/Utilities/PooledMemoryStream.cs.meta
+++ b/src/Runtime/Utilities/PooledMemoryStream.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 101fe22e59604101a41424be63eaac52
+timeCreated: 1708258836

--- a/src/Tests/PooledMemoryStreamTests.cs
+++ b/src/Tests/PooledMemoryStreamTests.cs
@@ -12,7 +12,7 @@ namespace Appegy.Storage
         public void WhenWriteFitsIntoCapacity_ThenBufferNotReallocated()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(1024);
+            stream.Reset();
             var buffer = stream.GetBuffer();
             var capacity = stream.Capacity;
 
@@ -27,7 +27,7 @@ namespace Appegy.Storage
         public void WhenWriteExceedsCapacity_ThenBufferGrownAndDataPreserved()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(256);
+            stream.Reset();
             var capacity = stream.Capacity;
             var payload = new byte[capacity + 100];
             for (var i = 0; i < payload.Length; i++)
@@ -45,16 +45,35 @@ namespace Appegy.Storage
         }
 
         [Test]
+        public void WhenBufferGrewOnce_ThenNextResetRentsGrownCapacity()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset();
+            var payload = new byte[stream.Capacity + 100];
+            stream.Write(payload, 0, payload.Length);
+            var grownCapacity = stream.Capacity;
+            stream.Release();
+
+            stream.Reset();
+
+            stream.Capacity.Should().Be(grownCapacity);
+            stream.Write(payload, 0, payload.Length);
+            stream.Capacity.Should().Be(grownCapacity);
+            stream.Release();
+        }
+
+        [Test]
         public void WhenReleased_ThenBufferReturnedToPool()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(1024);
+            stream.Reset();
             var buffer = stream.GetBuffer();
+            var capacity = stream.Capacity;
 
             stream.Release();
 
             stream.Capacity.Should().Be(0);
-            var rented = ArrayPool<byte>.Shared.Rent(1024);
+            var rented = ArrayPool<byte>.Shared.Rent(capacity);
             rented.Should().BeSameAs(buffer);
             ArrayPool<byte>.Shared.Return(rented);
         }
@@ -63,7 +82,7 @@ namespace Appegy.Storage
         public void WhenPositionMovedBack_ThenWriteOverwritesWithoutTruncating()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(64);
+            stream.Reset();
             stream.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
 
             stream.Position = 1;
@@ -80,7 +99,7 @@ namespace Appegy.Storage
         public void WhenPositionSetBeyondLength_ThenThrows()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(64);
+            stream.Reset();
             stream.Write(new byte[] { 1, 2 }, 0, 2);
 
             Action action = () => stream.Position = 3;
@@ -93,7 +112,7 @@ namespace Appegy.Storage
         public void WhenRead_ThenThrows()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(64);
+            stream.Reset();
 
             Action action = () => stream.Read(new byte[4], 0, 4);
 
@@ -105,10 +124,10 @@ namespace Appegy.Storage
         public void WhenReset_ThenPositionAndLengthAreZero()
         {
             var stream = new PooledMemoryStream();
-            stream.Reset(64);
+            stream.Reset();
             stream.Write(new byte[] { 1, 2, 3 }, 0, 3);
 
-            stream.Reset(64);
+            stream.Reset();
 
             stream.Length.Should().Be(0);
             stream.Position.Should().Be(0);

--- a/src/Tests/PooledMemoryStreamTests.cs
+++ b/src/Tests/PooledMemoryStreamTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Buffers;
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class PooledMemoryStreamTests
+    {
+        [Test]
+        public void WhenWriteFitsIntoCapacity_ThenBufferNotReallocated()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(1024);
+            var buffer = stream.GetBuffer();
+            var capacity = stream.Capacity;
+
+            stream.Write(new byte[capacity], 0, capacity);
+
+            stream.GetBuffer().Should().BeSameAs(buffer);
+            stream.Capacity.Should().Be(capacity);
+            stream.Release();
+        }
+
+        [Test]
+        public void WhenWriteExceedsCapacity_ThenBufferGrownAndDataPreserved()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(256);
+            var capacity = stream.Capacity;
+            var payload = new byte[capacity + 100];
+            for (var i = 0; i < payload.Length; i++)
+            {
+                payload[i] = (byte)(i % 251);
+            }
+
+            stream.Write(payload, 0, capacity);
+            stream.Write(payload, capacity, 100);
+
+            stream.Capacity.Should().BeGreaterThan(capacity);
+            stream.Length.Should().Be(payload.Length);
+            stream.GetBuffer().AsSpan(0, payload.Length).ToArray().Should().Equal(payload);
+            stream.Release();
+        }
+
+        [Test]
+        public void WhenReleased_ThenBufferReturnedToPool()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(1024);
+            var buffer = stream.GetBuffer();
+
+            stream.Release();
+
+            stream.Capacity.Should().Be(0);
+            var rented = ArrayPool<byte>.Shared.Rent(1024);
+            rented.Should().BeSameAs(buffer);
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+
+        [Test]
+        public void WhenPositionMovedBack_ThenWriteOverwritesWithoutTruncating()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(64);
+            stream.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
+
+            stream.Position = 1;
+            stream.Write(new byte[] { 9 }, 0, 1);
+            stream.Position = stream.Length;
+
+            stream.Length.Should().Be(4);
+            stream.Position.Should().Be(4);
+            stream.GetBuffer().AsSpan(0, 4).ToArray().Should().Equal(new byte[] { 1, 9, 3, 4 });
+            stream.Release();
+        }
+
+        [Test]
+        public void WhenPositionSetBeyondLength_ThenThrows()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(64);
+            stream.Write(new byte[] { 1, 2 }, 0, 2);
+
+            Action action = () => stream.Position = 3;
+
+            action.Should().Throw<ArgumentOutOfRangeException>();
+            stream.Release();
+        }
+
+        [Test]
+        public void WhenRead_ThenThrows()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(64);
+
+            Action action = () => stream.Read(new byte[4], 0, 4);
+
+            action.Should().Throw<NotSupportedException>();
+            stream.Release();
+        }
+
+        [Test]
+        public void WhenReset_ThenPositionAndLengthAreZero()
+        {
+            var stream = new PooledMemoryStream();
+            stream.Reset(64);
+            stream.Write(new byte[] { 1, 2, 3 }, 0, 3);
+
+            stream.Reset(64);
+
+            stream.Length.Should().Be(0);
+            stream.Position.Should().Be(0);
+            stream.Release();
+        }
+    }
+}

--- a/src/Tests/PooledMemoryStreamTests.cs.meta
+++ b/src/Tests/PooledMemoryStreamTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0869c2e921ad4de8bec6db506f675d78
+timeCreated: 1708258836

--- a/src/Tests/SaveBufferTests.cs
+++ b/src/Tests/SaveBufferTests.cs
@@ -109,24 +109,26 @@ namespace Appegy.Storage
         }
 
         [Test]
-        public void WhenDataSaved_ThenReturnedLengthMatchesFileSize()
+        public void WhenStorageIsEmpty_ThenFileDeleted()
         {
-            var (sections, data) = CreateSample(64, 512);
+            var sections = new List<BinarySection> { new TypedBinarySection<int>(Int32Serializer.Shared) };
+            File.WriteAllBytes(StoragePath, new byte[] { 1, 2, 3 });
 
-            var length = BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, new Dictionary<string, Record>());
 
-            length.Should().Be((int)new FileInfo(StoragePath).Length);
+            File.Exists(StoragePath).Should().BeFalse();
         }
 
         [Test]
-        public void WhenStorageIsEmpty_ThenSaveReportsZeroLength()
+        public void WhenBigStorageSavedBeforeSmallOne_ThenSmallOneIsStillCorrect()
         {
-            var sections = new List<BinarySection> { new TypedBinarySection<int>(Int32Serializer.Shared) };
+            var (bigSections, bigData) = CreateSample(64, 512);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, bigSections, bigData);
 
-            var length = BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, new Dictionary<string, Record>());
+            var (sections, data) = CreateSample(1, 8);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
 
-            length.Should().Be(0);
-            File.Exists(StoragePath).Should().BeFalse();
+            File.ReadAllBytes(StoragePath).Should().Equal(SerializeAsBeforeRefactor(sections, data));
         }
 
         private static (List<BinarySection> sections, Dictionary<string, Record> data) CreateSample(int stringKeys, int stringLength)

--- a/src/Tests/SaveBufferTests.cs
+++ b/src/Tests/SaveBufferTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Appegy.Storage.Serializers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class SaveBufferTests : BaseStorageTests
+    {
+        private string LegacyStoragePath => StoragePath + ".legacy";
+
+        [SetUp, TearDown]
+        public void CleanLegacyFileBetweenTests()
+        {
+            if (File.Exists(LegacyStoragePath))
+            {
+                File.Delete(LegacyStoragePath);
+            }
+        }
+
+        [Test]
+        public void WhenDataSerializedIntoBuffer_ThenBytesAreSameAsBeforeRefactor()
+        {
+            var (sections, data) = CreateSample(3, 16);
+
+            var expected = SerializeAsBeforeRefactor(sections, data);
+            var actual = SerializeIntoBuffer(sections, data);
+
+            actual.Should().Equal(expected);
+        }
+
+        [Test]
+        public void WhenFileSaved_ThenBytesAreSameAsBeforeRefactor()
+        {
+            var (sections, data) = CreateSample(3, 16);
+            File.WriteAllBytes(LegacyStoragePath, SerializeAsBeforeRefactor(sections, data));
+
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            File.ReadAllBytes(StoragePath).Should().Equal(File.ReadAllBytes(LegacyStoragePath));
+        }
+
+        [Test]
+        public void WhenDataExceedsInitialBuffer_ThenBytesAreSameAsBeforeRefactor()
+        {
+            var (sections, data) = CreateSample(64, 512);
+            File.WriteAllBytes(LegacyStoragePath, SerializeAsBeforeRefactor(sections, data));
+
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            File.ReadAllBytes(StoragePath).Should().Equal(File.ReadAllBytes(LegacyStoragePath));
+        }
+
+        [Test]
+        public void WhenDataExceedsInitialBuffer_AndStorageReloaded_ThenAllValuesAreValid()
+        {
+            var (sections, data) = CreateSample(64, 512);
+
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Get<int>("int").Should().Be(42);
+            storage.Get<string>("string_0").Should().Be(new string('x', 512));
+            storage.Get<string>("string_63").Should().Be(new string('x', 512));
+        }
+
+        [Test]
+        public void WhenSerializerThrows_ThenBufferReturnedToPool()
+        {
+            var (sections, data) = CreateThrowingSample();
+
+            var stream = BinaryStorageIO.SerializeToBuffer(new List<BinarySection>(), new Dictionary<string, Record>());
+            stream.Release();
+
+            Action action = () => BinaryStorageIO.SerializeToBuffer(sections, data);
+
+            action.Should().Throw<InvalidOperationException>();
+            stream.Capacity.Should().Be(0);
+        }
+
+        [Test]
+        public void WhenSerializerThrows_ThenNoFilesLeftOnDisk()
+        {
+            var (sections, data) = CreateThrowingSample();
+
+            Action action = () => BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            action.Should().Throw<InvalidOperationException>();
+            File.Exists(StoragePath).Should().BeFalse();
+            File.Exists(StoragePath + ".tmp").Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenSerializerThrew_ThenNextSaveWritesValidFile()
+        {
+            var (throwingSections, throwingData) = CreateThrowingSample();
+            Action action = () => BinaryStorageIO.SaveDataOnDisk(StoragePath, throwingSections, throwingData);
+            action.Should().Throw<InvalidOperationException>();
+
+            var (sections, data) = CreateSample(3, 16);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Get<int>("int").Should().Be(42);
+            storage.Get<string>("string_2").Should().Be(new string('x', 16));
+        }
+
+        [Test]
+        public void WhenDataSaved_ThenReturnedLengthMatchesFileSize()
+        {
+            var (sections, data) = CreateSample(64, 512);
+
+            var length = BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            length.Should().Be((int)new FileInfo(StoragePath).Length);
+        }
+
+        [Test]
+        public void WhenStorageIsEmpty_ThenSaveReportsZeroLength()
+        {
+            var sections = new List<BinarySection> { new TypedBinarySection<int>(Int32Serializer.Shared) };
+
+            var length = BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, new Dictionary<string, Record>());
+
+            length.Should().Be(0);
+            File.Exists(StoragePath).Should().BeFalse();
+        }
+
+        private static (List<BinarySection> sections, Dictionary<string, Record> data) CreateSample(int stringKeys, int stringLength)
+        {
+            var sections = new List<BinarySection>
+            {
+                new TypedBinarySection<int>(Int32Serializer.Shared),
+                new TypedBinarySection<string>(StringSerializer.Shared),
+                new TypedBinarySection<bool>(BooleanSerializer.Shared)
+            };
+            var data = new Dictionary<string, Record> { { "int", new Record<int>(42, 0) } };
+            sections[0].Count++;
+            var value = new string('x', stringLength);
+            for (var i = 0; i < stringKeys; i++)
+            {
+                data.Add($"string_{i}", new Record<string>(value, 1));
+                sections[1].Count++;
+            }
+            return (sections, data);
+        }
+
+        private static (List<BinarySection> sections, Dictionary<string, Record> data) CreateThrowingSample()
+        {
+            var sections = new List<BinarySection> { new TypedBinarySection<int>(new ThrowingSerializer()) };
+            var data = new Dictionary<string, Record> { { "boom", new Record<int>(1, 0) } };
+            sections[0].Count++;
+            return (sections, data);
+        }
+
+        private static byte[] SerializeIntoBuffer(IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data)
+        {
+            var stream = BinaryStorageIO.SerializeToBuffer(sections, data);
+            var bytes = new byte[stream.Length];
+            Array.Copy(stream.GetBuffer(), bytes, bytes.Length);
+            stream.Release();
+            return bytes;
+        }
+
+        private static byte[] SerializeAsBeforeRefactor(IReadOnlyList<BinarySection> sections, IReadOnlyDictionary<string, Record> data)
+        {
+            using var stream = new MemoryStream();
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8, true))
+            {
+                writer.Write(PackageInfo.Version);
+                writer.Write(0L);
+
+                writer.Write(sections.Count);
+                foreach (var section in sections)
+                {
+                    writer.Write(section.Count > 0 ? section.TypeName : string.Empty);
+                }
+
+                writer.Write(data.Count);
+                foreach (var entry in data)
+                {
+                    writer.Write(entry.Key);
+                    writer.Write(entry.Value.TypeIndex);
+
+                    var position = writer.BaseStream.Position;
+                    writer.Write(0L);
+
+                    var start = writer.BaseStream.Position;
+                    var serializer = sections[entry.Value.TypeIndex];
+                    serializer.WriteTo(writer, entry.Value);
+                    var entrySize = writer.BaseStream.Position - start;
+
+                    (position, writer.BaseStream.Position) = (writer.BaseStream.Position, position);
+                    writer.Write(entrySize);
+                    (_, writer.BaseStream.Position) = (writer.BaseStream.Position, position);
+                }
+            }
+            return stream.ToArray();
+        }
+
+        private class ThrowingSerializer : TypeSerializer<int>
+        {
+            public override string TypeName => "throwing";
+            public override bool Equals(int value1, int value2) => value1 == value2;
+            public override void WriteTo(BinaryWriter writer, int value) => throw new InvalidOperationException("Serializer failed on purpose");
+            public override int ReadFrom(BinaryReader reader) => reader.ReadInt32();
+        }
+    }
+}

--- a/src/Tests/SaveBufferTests.cs.meta
+++ b/src/Tests/SaveBufferTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9e753f122324444c8eb2bb11cf63d3d6
+timeCreated: 1708258836

--- a/src/Tests/ZeroAllocationTests.cs
+++ b/src/Tests/ZeroAllocationTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Appegy.Storage.Serializers;
 using FluentAssertions;
 using NUnit.Framework;
 using UnityEngine;
@@ -300,6 +302,38 @@ namespace Appegy.Storage
                 using (storage.MultipleChangeScope())
                 {
                 }
+            });
+        }
+
+        #endregion
+
+        #region Serialization
+
+        [Test]
+        public void WhenDataSerializedIntoBuffer_ThenNothingAllocated()
+        {
+            var sections = new List<BinarySection>
+            {
+                new TypedBinarySection<int>(Int32Serializer.Shared),
+                new TypedBinarySection<string>(StringSerializer.Shared)
+            };
+            var data = new Dictionary<string, Record>
+            {
+                { "int", new Record<int>(42, 0) },
+                { "string", new Record<string>("hello", 1) }
+            };
+            sections[0].Count++;
+            sections[1].Count++;
+
+            var warmup = BinaryStorageIO.SerializeToBuffer(sections, data);
+            var sizeHint = (int)warmup.Length;
+            warmup.Release();
+
+            ShouldNotAllocate("BinaryStorageIO.SerializeToBuffer", () =>
+            {
+                var stream = BinaryStorageIO.SerializeToBuffer(sections, data, sizeHint);
+                _intSink += (int)stream.Length;
+                stream.Release();
             });
         }
 

--- a/src/Tests/ZeroAllocationTests.cs
+++ b/src/Tests/ZeroAllocationTests.cs
@@ -325,13 +325,9 @@ namespace Appegy.Storage
             sections[0].Count++;
             sections[1].Count++;
 
-            var warmup = BinaryStorageIO.SerializeToBuffer(sections, data);
-            var sizeHint = (int)warmup.Length;
-            warmup.Release();
-
             ShouldNotAllocate("BinaryStorageIO.SerializeToBuffer", () =>
             {
-                var stream = BinaryStorageIO.SerializeToBuffer(sections, data, sizeHint);
+                var stream = BinaryStorageIO.SerializeToBuffer(sections, data);
                 _intSink += (int)stream.Length;
                 stream.Release();
             });

--- a/tools/unity-mcp.py
+++ b/tools/unity-mcp.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Launch the MCP for Unity server, routed to THIS checkout's Unity Editor.
+
+Invoked from .mcp.json. The Unity subfolder name is passed as argv[1] so this
+script stays identical across repos/worktrees.
+
+It derives the Unity project hash like the Editor bridge
+(ProjectIdentityUtility.ComputeProjectHash: hex of sha1(Application.dataPath)),
+then starts the server with --default-instance <hash>. Routing by hash (which is
+a function of the absolute project path) is what makes a worktree resolve to its
+own Editor instead of the main checkout's - their project names are identical, only
+the path-derived hash differs.
+
+We use the first 8 hex chars: that is exactly what Unity names its stdio status
+file (unity-mcp-status-<8>.json), so it matches by `==` in stdio discovery, and it
+also prefix-matches the 16-char hash the HTTP hub reports - one value works in both.
+"""
+import hashlib
+import os
+import subprocess
+import sys
+
+SERVER_PACKAGE = "mcpforunityserver==10.1.0"
+
+unity_subdir = sys.argv[1]
+
+# CLAUDE_PROJECT_DIR is set by Claude Code to the checkout/worktree root. Forward
+# slashes + no trailing slash match Unity's Application.dataPath on every platform.
+root = (os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()).replace("\\", "/").rstrip("/")
+data_path = f"{root}/{unity_subdir}/Assets"
+project_hash = hashlib.sha1(data_path.encode("utf-8")).hexdigest()[:8]
+
+sys.exit(subprocess.run([
+    "uvx", "--from", SERVER_PACKAGE, "mcp-for-unity",
+    "--transport", "stdio",
+    "--default-instance", project_hash,
+]).returncode)


### PR DESCRIPTION
Saving no longer seeks back and forth over the file to backpatch entry sizes. The storage is serialized into a pooled buffer first and written with a single call, so the backward jumps become array indexing instead of lseek/write syscalls on the main thread.

Byte format is unchanged — a test compares the output against a replica of the pre-refactor writer, both for the buffer and for the file on disk.