### PR TITLE
fix: publish storage file atomically with File.Replace

### DIFF
--- a/src/Runtime/BinaryStorage.Builder.cs
+++ b/src/Runtime/BinaryStorage.Builder.cs
@@ -36,9 +36,16 @@ namespace Appegy.Storage
         /// <param name="storagePath">The path to the storage file.</param>
         internal static void Delete(string storagePath)
         {
-            if (File.Exists(storagePath))
+            DeleteIfExists(storagePath);
+            DeleteIfExists(storagePath + BinaryStorageIO.TempFileExtension);
+            DeleteIfExists(storagePath + BinaryStorageIO.BackupFileExtension);
+        }
+
+        private static void DeleteIfExists(string filePath)
+        {
+            if (File.Exists(filePath))
             {
-                File.Delete(storagePath);
+                File.Delete(filePath);
             }
         }
 

--- a/src/Runtime/BinaryStorageIO.cs
+++ b/src/Runtime/BinaryStorageIO.cs
@@ -8,6 +8,9 @@ namespace Appegy.Storage
 {
     internal static class BinaryStorageIO
     {
+        internal const string TempFileExtension = ".tmp";
+        internal const string BackupFileExtension = ".bak";
+
         [ThreadStatic] private static PooledMemoryStream _serializationStream;
         [ThreadStatic] private static BinaryWriter _serializationWriter;
 
@@ -19,13 +22,15 @@ namespace Appegy.Storage
         internal static void SaveDataOnDisk(string storageFilePath, IReadOnlyList<BinarySection> sections, Dictionary<string, Record> data)
         {
             // make sure there is no temp file from previous (most likely failed) save try
-            var storageFilePathTmp = storageFilePath + ".tmp";
+            var storageFilePathTmp = storageFilePath + TempFileExtension;
+            var storageFilePathBackup = storageFilePath + BackupFileExtension;
             DeleteFileIfExists(storageFilePathTmp);
 
             // delete storage if it exists when no data
             if (data.Count == 0)
             {
                 DeleteFileIfExists(storageFilePath);
+                DeleteFileIfExists(storageFilePathBackup);
                 return;
             }
 
@@ -50,9 +55,12 @@ namespace Appegy.Storage
 
             if (File.Exists(storageFilePath))
             {
-                File.Delete(storageFilePath);
+                File.Replace(storageFilePathTmp, storageFilePath, storageFilePathBackup);
             }
-            File.Move(storageFilePathTmp, storageFilePath);
+            else
+            {
+                File.Move(storageFilePathTmp, storageFilePath);
+            }
         }
 
         /// <summary> Serialize data into a pooled in-memory buffer. Caller owns the returned stream and must call <see cref="PooledMemoryStream.Release"/>. </summary>

--- a/src/Tests/AtomicPublishTests.cs
+++ b/src/Tests/AtomicPublishTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using System.IO;
+using Appegy.Storage.Serializers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.Storage
+{
+    public class AtomicPublishTests : BaseStorageTests
+    {
+        [Test]
+        public void WhenSavedFirstTime_ThenNoBackupCreated()
+        {
+            var (sections, data) = CreateSample(1);
+
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            File.Exists(StoragePath).Should().BeTrue();
+            File.Exists(BackupPath).Should().BeFalse();
+            File.Exists(TempPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenSavedOverExistingFile_ThenBackupHoldsPreviousGeneration()
+        {
+            var (firstSections, firstData) = CreateSample(1);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, firstSections, firstData);
+            var firstGeneration = File.ReadAllBytes(StoragePath);
+
+            var (secondSections, secondData) = CreateSample(2);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, secondSections, secondData);
+
+            File.ReadAllBytes(BackupPath).Should().Equal(firstGeneration);
+            File.ReadAllBytes(StoragePath).Should().NotEqual(firstGeneration);
+            File.Exists(TempPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenSavedOverExistingFile_ThenBackupIsLoadable()
+        {
+            var (firstSections, firstData) = CreateSample(1);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, firstSections, firstData);
+
+            var (secondSections, secondData) = CreateSample(2);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, secondSections, secondData);
+
+            var sections = CreateSections();
+            var loaded = new Dictionary<string, Record>();
+            BinaryStorageIO.LoadDataFromDisk(BackupPath, sections, loaded, KeyLoadFailedBehaviour.ThrowException);
+
+            loaded.Should().ContainKey("value");
+            ((Record<int>)loaded["value"]).Value.Should().Be(1);
+        }
+
+        [Test]
+        public void WhenSavedManyTimes_ThenBackupAlwaysHoldsOneGenerationBack()
+        {
+            for (var generation = 1; generation <= 5; generation++)
+            {
+                var (sections, data) = CreateSample(generation);
+                BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+            }
+
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Get<int>("value").Should().Be(5);
+
+            var backupSections = CreateSections();
+            var backup = new Dictionary<string, Record>();
+            BinaryStorageIO.LoadDataFromDisk(BackupPath, backupSections, backup, KeyLoadFailedBehaviour.ThrowException);
+            ((Record<int>)backup["value"]).Value.Should().Be(4);
+        }
+
+        [Test]
+        public void WhenSavedRepeatedly_ThenStorageFileIsNeverMissing()
+        {
+            var (firstSections, firstData) = CreateSample(1);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, firstSections, firstData);
+
+            var observer = new FileExistenceObserver(StoragePath, BackupPath);
+            observer.Start();
+            for (var generation = 2; generation <= 201; generation++)
+            {
+                var (sections, data) = CreateSample(generation);
+                BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+            }
+            observer.Stop();
+
+            observer.SawBothMissing.Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenAllDataRemoved_ThenBackupRemovedToo()
+        {
+            var (firstSections, firstData) = CreateSample(1);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, firstSections, firstData);
+            var (secondSections, secondData) = CreateSample(2);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, secondSections, secondData);
+            File.Exists(BackupPath).Should().BeTrue();
+
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, CreateSections(), new Dictionary<string, Record>());
+
+            File.Exists(StoragePath).Should().BeFalse();
+            File.Exists(BackupPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenStorageDeleted_ThenBackupAndTempDeletedToo()
+        {
+            var (firstSections, firstData) = CreateSample(1);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, firstSections, firstData);
+            var (secondSections, secondData) = CreateSample(2);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, secondSections, secondData);
+            File.WriteAllBytes(TempPath, new byte[] { 1, 2, 3 });
+
+            BinaryStorage.Delete(StoragePath);
+
+            File.Exists(StoragePath).Should().BeFalse();
+            File.Exists(BackupPath).Should().BeFalse();
+            File.Exists(TempPath).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenStaleTempExists_ThenSaveStillPublishes()
+        {
+            var (firstSections, firstData) = CreateSample(1);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, firstSections, firstData);
+            File.WriteAllBytes(TempPath, new byte[] { 9, 9, 9 });
+
+            var (sections, data) = CreateSample(2);
+            BinaryStorageIO.SaveDataOnDisk(StoragePath, sections, data);
+
+            using var storage = BinaryStorage.Construct(StoragePath).AddPrimitiveTypes().Build();
+            storage.Get<int>("value").Should().Be(2);
+            File.Exists(TempPath).Should().BeFalse();
+        }
+
+        private static List<BinarySection> CreateSections()
+        {
+            return new List<BinarySection> { new TypedBinarySection<int>(Int32Serializer.Shared) };
+        }
+
+        private static (List<BinarySection> sections, Dictionary<string, Record> data) CreateSample(int value)
+        {
+            var sections = CreateSections();
+            var data = new Dictionary<string, Record> { { "value", new Record<int>(value, 0) } };
+            sections[0].Count++;
+            return (sections, data);
+        }
+
+        private class FileExistenceObserver
+        {
+            private readonly string _storagePath;
+            private readonly string _backupPath;
+            private readonly System.Threading.Thread _thread;
+            private volatile bool _running;
+
+            public bool SawBothMissing { get; private set; }
+
+            public FileExistenceObserver(string storagePath, string backupPath)
+            {
+                _storagePath = storagePath;
+                _backupPath = backupPath;
+                _thread = new System.Threading.Thread(Observe) { IsBackground = true };
+            }
+
+            public void Start()
+            {
+                _running = true;
+                _thread.Start();
+            }
+
+            public void Stop()
+            {
+                _running = false;
+                _thread.Join();
+            }
+
+            private void Observe()
+            {
+                while (_running)
+                {
+                    if (!File.Exists(_storagePath) && !File.Exists(_backupPath))
+                    {
+                        SawBothMissing = true;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/AtomicPublishTests.cs.meta
+++ b/src/Tests/AtomicPublishTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eddf75ad2fff54c4e99a557c434aad30

--- a/src/Tests/BaseStorageTests.cs
+++ b/src/Tests/BaseStorageTests.cs
@@ -8,12 +8,22 @@ namespace Appegy.Storage
     {
         protected readonly string StoragePath = Path.Combine(Application.temporaryCachePath, "test.bin");
 
+        protected string TempPath => StoragePath + BinaryStorageIO.TempFileExtension;
+        protected string BackupPath => StoragePath + BinaryStorageIO.BackupFileExtension;
+
         [SetUp, TearDown]
         public void CleanStorageBetweenTests()
         {
-            if (File.Exists(StoragePath))
+            DeleteIfExists(StoragePath);
+            DeleteIfExists(TempPath);
+            DeleteIfExists(BackupPath);
+        }
+
+        private static void DeleteIfExists(string filePath)
+        {
+            if (File.Exists(filePath))
             {
-                File.Delete(StoragePath);
+                File.Delete(filePath);
             }
         }
     }


### PR DESCRIPTION
The storage file is now published with `File.Replace` instead of deleting it and moving the temp file over it. The old sequence left a window where the storage file did not exist at all, so dying in that window lost everything. A `.bak` file holding the previous generation now sits next to the storage, and is removed together with it.