### PR TITLE
refactor: drop the storage finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - `IsDirty`. With auto-save on it was almost always `false`, and with the background writer it meant "no change is waiting to be handed over", not "everything is on disk". Use `Save()` when you need the data on disk.
+- The `BinaryStorage` finalizer. It held no unmanaged resources to release, it never saved anything, and the only thing it did was release the editor-side path lock from the finalizer thread while the main thread could be reading the same set. A storage that is never disposed now keeps that lock until the domain reloads, so dispose your storages, as before.
 
 ### Fixed
 - Two storages opened through paths that differ only in form (`a/save.dat` and `./a/save.dat`) no longer publish the same file without serializing against each other.

--- a/src/Runtime/BinaryStorage.cs
+++ b/src/Runtime/BinaryStorage.cs
@@ -653,43 +653,25 @@ namespace Appegy.Storage
 
         #endregion
 
-        #region Dispose Pattern
+        #region Dispose
 
-        /// <summary> Finalizer </summary>
-        ~BinaryStorage()
-        {
-            Dispose(false);
-        }
-
-        /// <summary> Disposes the resources used by the storage. </summary>
+        /// <summary> Writes any unsaved data to disk, disposes the stored collections and releases the storage. </summary>
         public virtual void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary> Disposes the resources used by the storage. </summary>
-        /// <param name="disposing">Whether managed resources should be disposed.</param>
-        private void Dispose(bool disposing)
         {
             if (IsDisposed)
             {
                 return;
             }
 
-            if (disposing)
+            if (AutoSave && _hasUnsavedChanges)
             {
-                if (AutoSave && _hasUnsavedChanges)
-                {
-                    SaveDataOnDisk(true);
-                }
-                else
-                {
-                    _persistence.Flush();
-                }
+                SaveDataOnDisk(true);
+            }
+            else
+            {
+                _persistence.Flush();
             }
 
-            // Always dispose IReactiveCollection instances
             foreach (var record in _data.Values)
             {
                 UntrackCollectionOf(record);
@@ -699,13 +681,10 @@ namespace Appegy.Storage
             OnKeyChanged = null;
             OnKeyRemoved = null;
 
-            if (disposing)
+            _data.Clear();
+            for (var i = 0; i < _supportedTypes.Count; i++)
             {
-                _data.Clear();
-                for (var i = 0; i < _supportedTypes.Count; i++)
-                {
-                    _supportedTypes[i].Count = 0;
-                }
+                _supportedTypes[i].Count = 0;
             }
 
             IsDisposed = true;


### PR DESCRIPTION
Stacked on #91, so this diff shows only the finalizer change. GitHub retargets it to `main` once #91 merges.

`BinaryStorage` holds no unmanaged resources: a dictionary, records, reactive collections, and a persistence layer whose only `FileStream` is opened and closed inside a single method. The finalizer arrived in #33, a documentation commit, as part of laying out the textbook dispose pattern - nothing asked for it.

On the finalizer thread it skipped the save, then disposed reactive collections that were already unreachable and had no finalizers of their own, and finally released the editor path lock by mutating a static `HashSet<string>` with no lock while the main thread could be reading the same set from `Construct`. In player builds that last call is compiled out entirely, so the whole pass was dead work there.

With the finalizer gone, `disposing` is always true, so `Dispose(bool)` folds back into `Dispose()`.

Behaviour change: a storage that is never disposed no longer has its editor path lock released by the GC, so a second `Construct` on the same path will keep throwing until the domain reloads. Nothing changes for storages that are disposed, and no unsaved data was ever written by the finalizer.